### PR TITLE
Add Protection Module Support

### DIFF
--- a/src/main/java/me/justahuman/spiritsunchained/listeners/IdentifyingGlassListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/IdentifyingGlassListener.java
@@ -1,8 +1,10 @@
 package me.justahuman.spiritsunchained.listeners;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 
 import me.justahuman.spiritsunchained.SpiritsUnchained;
@@ -34,7 +36,7 @@ public class IdentifyingGlassListener implements Listener {
     public void onSpyglassLook(PlayerStatisticIncrementEvent evt) {
         final Player player = evt.getPlayer();
 
-        if (evt.getStatistic() != Statistic.USE_ITEM || evt.getMaterial() != Material.SPYGLASS) {
+        if (evt.getStatistic() != Statistic.USE_ITEM || evt.getMaterial() != Material.SPYGLASS || !Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.INTERACT_ENTITY)) {
             return;
         }
 

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
@@ -1,8 +1,10 @@
 package me.justahuman.spiritsunchained.listeners;
 
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.implementation.mobs.AbstractCustomMob;
 import me.justahuman.spiritsunchained.utils.Keys;
@@ -59,9 +61,13 @@ public class PlayerClickListener implements Listener {
             for (Entity entity : lookingAt) {
                 final AbstractCustomMob<?> maybe = SpiritsUnchained.getSpiritEntityManager().getCustomClass(entity, null);
                 if (entity instanceof Allay && maybe != null && player.getLocation().distance(entity.getLocation()) < 4) {
+                    if (!Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.INTERACT_ENTITY)) {
+                        player.sendMessage(ChatColors.color("&cYou do not have Entity Interaction Permissions in this area!"));
+                        return;
+                    }
                     e.setCancelled(true);
                     maybe.onInteract(new PlayerInteractEntityEvent(player, entity, e.getHand()));
-                    break;
+                    return;
                 }
             }
         }
@@ -79,7 +85,7 @@ public class PlayerClickListener implements Listener {
                 }
                 final String type = PersistentDataAPI.getString(item.getItemMeta(), Keys.spiritItemKey);
                 final Map<String, Object> traitInfo = SpiritUtils.getTraitInfo(SpiritsUnchained.getSpiritsManager().getSpiritMap().get(EntityType.valueOf(type)).getTrait());
-                player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColors.color(SpiritTraits.useTrait(player, traitInfo, PersistentDataAPI.getString(item.getItemMeta(), Keys.spiritStateKey), PersistentDataAPI.getString(item.getItemMeta(), Keys.spiritItemKey)))));
+                player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColors.color(SpiritTraits.useTrait(player, traitInfo, PersistentDataAPI.getString(item.getItemMeta(), Keys.spiritItemKey)))));
                 return true;
             }
         }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
@@ -78,7 +78,7 @@ public class TraitListeners implements Listener {
             return;
         }
 
-        if (PersistentDataAPI.getString(exploding, Keys.entityKey).equals("DullExplosion")) {
+        if (PersistentDataAPI.getString(exploding, Keys.entityKey).equals("DullExplosion") || PersistentDataAPI.getString(exploding, Keys.entityKey).equals("Skull_Fire")) {
             event.blockList().clear();
         }
     }

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
@@ -1,6 +1,9 @@
 package me.justahuman.spiritsunchained.utils;
 
+import io.github.bakedlibs.dough.protection.modules.GriefPreventionProtectionModule;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 
@@ -52,14 +55,14 @@ public class SpiritTraits {
 
     static final Map<UUID, Map<String, Long>> Cooldown_Map = new HashMap<>();
 
-    public static String useTrait(Player player, Map<String, Object> traitInfo, String state, String type) {
+    public static String useTrait(Player player, Map<String, Object> traitInfo, String type) {
         final UUID uuid = player.getUniqueId();
         final String name = (String) traitInfo.get("name");
         final String id = (String) traitInfo.get("id");
         final Method traitMethod;
 
-        if (SpiritUtils.getStates().indexOf(state) <= 2) {
-            return ChatUtils.humanize(type) + " Spirit needs to be to the Gentle State or Higher!";
+        if (!Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.INTERACT_BLOCK) || !Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.PLACE_BLOCK) || !Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.BREAK_BLOCK) || !Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.ATTACK_ENTITY) || !Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.ATTACK_PLAYER) || !Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.INTERACT_ENTITY)) {
+            return "&cYou do not have the required permissions in this area!";
         }
 
         if (traitInfo.get("type").equals("Passive")) {
@@ -79,6 +82,10 @@ public class SpiritTraits {
             return name + " on Cooldown! (" + cooldown + "s)";
         }
 
+        if (!SpiritUtils.useSpiritItem(player, EntityType.valueOf(type))) {
+            return ChatUtils.humanize(type) + " Spirit does not have a high enough State or Progress!!";
+        }
+
         try {
             traitMethod.invoke(SpiritTraits.class, player);
         } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
@@ -90,9 +97,6 @@ public class SpiritTraits {
         final Map<String, Long> cooldownMap = Cooldown_Map.containsKey(uuid) ? Cooldown_Map.get(uuid) : new HashMap<>();
         cooldownMap.put((String) traitInfo.get("id"), System.currentTimeMillis() + (int) traitInfo.get("cooldown") * 1000);
         Cooldown_Map.put(uuid, cooldownMap);
-
-        //Use 'Durability'
-        SpiritUtils.useSpiritItem(player, EntityType.valueOf(type));
 
         return name + " Used!";
     }


### PR DESCRIPTION
- Players now must have all interaction perms to use any spirits trait
- Players must have the entity interact permission to catch, bottle, or identify spirits