### PR TITLE
New Optimizations, Bug Fixes, and Features!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Spirits Unchained
+## Download Spirits Unchained
+
+[![Build Status](https://thebusybiscuit.github.io/builds/JustAHuman-xD/SpiritsUnchained/master/badge.svg)](https://thebusybiscuit.github.io/builds/JustAHuman-xD/SpiritsUnchained/master/)
+
+# About Spirits Unchained
 Spirits Requires Paper Minecraft 1.19 or higher
 
 All of the config files *can* be edited, but the only ones I would recommend editing are the config.yml (naturally), traits.yml (for cooldowns), the rewards.yml (for the passing on rewards), and both language.yml & books.yml for translations.

--- a/src/main/java/me/justahuman/spiritsunchained/Setup.java
+++ b/src/main/java/me/justahuman/spiritsunchained/Setup.java
@@ -10,7 +10,6 @@ import me.justahuman.spiritsunchained.slimefun.Items;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
-import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 
 public class Setup {
 

--- a/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
+++ b/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
@@ -1,28 +1,20 @@
 package me.justahuman.spiritsunchained;
 
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-
-import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.GitHubBuildsUpdater;
 import lombok.Getter;
 import me.justahuman.spiritsunchained.managers.CommandManager;
-import me.justahuman.spiritsunchained.slimefun.Researches;
-import me.justahuman.spiritsunchained.utils.Keys;
-import me.justahuman.spiritsunchained.utils.LogUtils;
 import me.justahuman.spiritsunchained.managers.ConfigManager;
 import me.justahuman.spiritsunchained.managers.ListenerManager;
 import me.justahuman.spiritsunchained.managers.RunnableManager;
 import me.justahuman.spiritsunchained.managers.SpiritEntityManager;
 import me.justahuman.spiritsunchained.managers.SpiritsManager;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
-
-import me.justahuman.spiritsunchained.utils.SpiritUtils;
+import me.justahuman.spiritsunchained.slimefun.Researches;
+import me.justahuman.spiritsunchained.utils.LogUtils;
 import org.bstats.bukkit.Metrics;
-import org.bukkit.Bukkit;
-import org.bukkit.World;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.plugin.java.JavaPlugin;

--- a/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
+++ b/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
@@ -15,12 +15,15 @@ import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 import me.justahuman.spiritsunchained.slimefun.Researches;
 import me.justahuman.spiritsunchained.utils.LogUtils;
 import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.UUID;
 
 public class SpiritsUnchained extends JavaPlugin implements SlimefunAddon {
 
@@ -99,11 +102,14 @@ public class SpiritsUnchained extends JavaPlugin implements SlimefunAddon {
     @Override
     public void onDisable() {
         configManager.save();
-        for (LivingEntity livingEntity : getSpiritEntityManager().entityCollection) {
+        for (LivingEntity livingEntity : getSpiritEntityManager().getCustomLivingEntities()) {
             livingEntity.remove();
         }
-        for (FallingBlock fallingBlock : getCommandManager().ghostBlocks) {
-            fallingBlock.remove();
+        for (UUID uuid : getCommandManager().ghostBlocks) {
+            final Entity fallingBlock = Bukkit.getEntity(uuid);
+            if (fallingBlock != null) {
+                fallingBlock.remove();
+            }
         }
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
+++ b/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
@@ -24,6 +24,7 @@ import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.annotation.Nonnull;
@@ -43,6 +44,8 @@ public class SpiritsUnchained extends JavaPlugin implements SlimefunAddon {
     private static ConfigManager configManager;
     @Getter
     private static RunnableManager runnableManager;
+    @Getter
+    private static CommandManager commandManager;
 
     @Override
     public void onEnable() {
@@ -54,12 +57,13 @@ public class SpiritsUnchained extends JavaPlugin implements SlimefunAddon {
         getLogger().info("========================================");
 
         saveDefaultConfig();
-
+        
         configManager = new ConfigManager();
         runnableManager = new RunnableManager();
         listenerManager = new ListenerManager();
         spiritsManager = new SpiritsManager();
         spiritEntityManager = new SpiritEntityManager();
+        commandManager = new CommandManager();
 
         Setup.INSTANCE.init();
 
@@ -74,7 +78,7 @@ public class SpiritsUnchained extends JavaPlugin implements SlimefunAddon {
 
         final Metrics metrics = new Metrics(this, 16817);
 
-        this.getCommand("spirits").setExecutor(new CommandManager());
+        this.getCommand("spirits").setExecutor(commandManager);
     }
 
     @Nonnull
@@ -103,12 +107,11 @@ public class SpiritsUnchained extends JavaPlugin implements SlimefunAddon {
     @Override
     public void onDisable() {
         configManager.save();
-        for (World world : Bukkit.getWorlds()) {
-            for (FallingBlock fallingBlock : world.getEntitiesByClass(FallingBlock.class)) {
-                if (PersistentDataAPI.hasString(fallingBlock, Keys.entityKey)) {
-                    fallingBlock.remove();
-                }
-            }
+        for (LivingEntity livingEntity : getSpiritEntityManager().entityCollection) {
+            livingEntity.remove();
+        }
+        for (FallingBlock fallingBlock : getCommandManager().ghostBlocks) {
+            fallingBlock.remove();
         }
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
+++ b/src/main/java/me/justahuman/spiritsunchained/SpiritsUnchained.java
@@ -17,7 +17,6 @@ import me.justahuman.spiritsunchained.utils.LogUtils;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.plugin.java.JavaPlugin;
 

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
@@ -150,8 +150,8 @@ public class ElectricSpiritBottler extends SlimefunItem implements EnergyNetComp
         final int outputSlot = inv.getItemInSlot(24) == null ? 24 : 25;
 
         LivingEntity target = null;
-        for (LivingEntity livingEntity : spiritEntityManager.entityCollection) {
-            if (!PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked) && livingEntity.getLocation().isWorldLoaded() && location.isWorldLoaded() && livingEntity.getLocation().getWorld() == location.getWorld() && location.distanceSquared(livingEntity.getLocation()) <= Math.pow(16, 2)) {
+        for (LivingEntity livingEntity : SpiritUtils.getNearbySpirits(location, 16)) {
+            if (!PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked)) {
                 target = livingEntity;
                 break;
             }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
@@ -15,7 +15,6 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 
 import me.justahuman.spiritsunchained.SpiritsUnchained;
-import me.justahuman.spiritsunchained.managers.SpiritEntityManager;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
@@ -52,14 +51,11 @@ public class ElectricSpiritBottler extends SlimefunItem implements EnergyNetComp
     private static final int[] BORDER_OUTPUT = new int[]{14,15,16,17,23,26,32,33,34,35};
     private static final int[] INPUT_SLOTS = new int[]{19,20};
     private static final int[] OUTPUT_SLOTS = new int[]{24,25};
-    private final SpiritEntityManager spiritEntityManager;
-
     private static final Map<BlockPosition, Boolean> catching = new HashMap<>();
 
     @ParametersAreNonnullByDefault
     public ElectricSpiritBottler(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
-        spiritEntityManager = SpiritsUnchained.getSpiritEntityManager();
 
         buildPreset();
         addItemHandler(onBreak());
@@ -194,7 +190,7 @@ public class ElectricSpiritBottler extends SlimefunItem implements EnergyNetComp
     public int getCapacity() {
         return 2000;
     }
-
+    
     public static int getEnergyConsumption() {
         return 100;
     }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
@@ -66,7 +66,7 @@ public class ElectricSpiritBottler extends SlimefunItem implements EnergyNetComp
     }
 
     private void buildPreset() {
-        new BlockMenuPreset(this.getId(), SpiritUtils.getTranslation("names.items.electric_spirit_catcher.name")) {
+        new BlockMenuPreset(this.getId(), SpiritUtils.getTranslation("names.items.electric_spirit_bottler.name")) {
             @Override
             public void init() {
                 ChestMenuUtils.drawBackground(this, BACKGROUND_SLOTS);

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritBottler.java
@@ -151,7 +151,7 @@ public class ElectricSpiritBottler extends SlimefunItem implements EnergyNetComp
 
         LivingEntity target = null;
         for (LivingEntity livingEntity : spiritEntityManager.entityCollection) {
-            if (livingEntity.getLocation().isWorldLoaded() && location.isWorldLoaded() && livingEntity.getLocation().getWorld() == location.getWorld() && location.distance(livingEntity.getLocation()) <= 10 && !PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked)) {
+            if (!PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked) && livingEntity.getLocation().isWorldLoaded() && location.isWorldLoaded() && livingEntity.getLocation().getWorld() == location.getWorld() && location.distanceSquared(livingEntity.getLocation()) <= Math.pow(16, 2)) {
                 target = livingEntity;
                 break;
             }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritCatcher.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritCatcher.java
@@ -154,8 +154,8 @@ public class ElectricSpiritCatcher extends SlimefunItem implements EnergyNetComp
         final int outputSlot = inv.getItemInSlot(24) == null ? 24 : 25;
 
         LivingEntity target = null;
-        for (LivingEntity livingEntity : spiritEntityManager.entityCollection) {
-            if (!PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked) && livingEntity.getLocation().isWorldLoaded() && location.isWorldLoaded() && livingEntity.getLocation().getWorld() == location.getWorld() && location.distanceSquared(livingEntity.getLocation()) <= Math.pow(16, 2)) {
+        for (LivingEntity livingEntity : SpiritUtils.getNearbySpirits(location, 16)) {
+            if (!PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked)) {
                 target = livingEntity;
                 break;
             }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritCatcher.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritCatcher.java
@@ -155,7 +155,7 @@ public class ElectricSpiritCatcher extends SlimefunItem implements EnergyNetComp
 
         LivingEntity target = null;
         for (LivingEntity livingEntity : spiritEntityManager.entityCollection) {
-            if (location.distance(livingEntity.getLocation()) <= 10 && !PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked)) {
+            if (!PersistentDataAPI.hasBoolean(livingEntity, Keys.spiritLocked) && livingEntity.getLocation().isWorldLoaded() && location.isWorldLoaded() && livingEntity.getLocation().getWorld() == location.getWorld() && location.distanceSquared(livingEntity.getLocation()) <= Math.pow(16, 2)) {
                 target = livingEntity;
                 break;
             }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritWriter.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/machines/ElectricSpiritWriter.java
@@ -26,7 +26,6 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
@@ -51,7 +51,7 @@ public abstract class AbstractCustomMob<T extends LivingEntity> {
     @Nonnull
     public T spawn(@Nonnull Location loc, @Nonnull World world, String reason, String type) {
         final T mob = world.spawn(loc, this.clazz);
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob);
+        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
 
         PersistentDataAPI.setString(mob, Keys.entityKey, this.id);
 

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
@@ -51,7 +51,7 @@ public abstract class AbstractCustomMob<T extends LivingEntity> {
     @Nonnull
     public T spawn(@Nonnull Location loc, @Nonnull World world, String reason, String type) {
         final T mob = world.spawn(loc, this.clazz);
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
+        SpiritsUnchained.getSpiritEntityManager().entitySet.add(mob.getUniqueId());
 
         PersistentDataAPI.setString(mob, Keys.entityKey, this.id);
 

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
@@ -11,6 +11,7 @@ import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.managers.SpiritEntityManager;
 import me.justahuman.spiritsunchained.utils.Keys;
 
+import net.kyori.adventure.text.Component;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.attribute.Attribute;
@@ -56,7 +57,7 @@ public abstract class AbstractCustomMob<T extends LivingEntity> {
 
         Objects.requireNonNull(mob.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(this.maxHealth);
         mob.setHealth(this.maxHealth);
-        mob.setCustomName(this.name);
+        mob.customName(Component.text(this.name));
         mob.setCustomNameVisible(true);
         mob.setRemoveWhenFarAway(true);
 

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/AbstractCustomMob.java
@@ -85,15 +85,15 @@ public abstract class AbstractCustomMob<T extends LivingEntity> {
 
     public void onTick(@Nonnull T mob) { }
 
-    public void onInteract(@Nonnull PlayerInteractEntityEvent e) { }
+    public void onInteract(@Nonnull PlayerInteractEntityEvent event) { }
 
-    public void onHit(@Nonnull EntityDamageByEntityEvent e) { }
+    public void onHit(@Nonnull EntityDamageByEntityEvent event) { }
 
-    public void onTarget(@Nonnull EntityTargetEvent e) { }
+    public void onTarget(@Nonnull EntityTargetEvent event) { }
 
-    public void onDeath(@Nonnull EntityDeathEvent e) { }
+    public void onDeath(@Nonnull EntityDeathEvent event) { }
 
-    public void onDamage(@Nonnull EntityDamageEvent e) { }
+    public void onDamage(@Nonnull EntityDamageEvent event) { }
 
     @ParametersAreNonnullByDefault
     public void reveal(Allay currentEntity, Player player) {}

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
@@ -61,7 +61,7 @@ public class Spirit extends AbstractCustomMob<Allay> {
         }
 
         final Allay mob = world.spawn(loc, this.getClazz());
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
+        SpiritsUnchained.getSpiritEntityManager().entitySet.add(mob.getUniqueId());
         PersistentDataAPI.setString(mob, Keys.entityKey, this.getId());
         PersistentDataAPI.setString(mob, Keys.spiritStateKey, state);
         PersistentDataAPI.setLong(mob, Keys.despawnKey, System.currentTimeMillis() + SpiritUtils.random((long) (definition.getTier() * 60L * 0.75), definition.getTier() * 60 * SpiritUtils.random(1, 3)) * 1000);

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
@@ -21,7 +21,6 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -63,7 +62,6 @@ public class Spirit extends AbstractCustomMob<Allay> {
 
         final Allay mob = world.spawn(loc, this.getClazz());
         SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
-        SpiritUtils.spiritIdMap.put(mob.getEntityId(), mob);
         PersistentDataAPI.setString(mob, Keys.entityKey, this.getId());
         PersistentDataAPI.setString(mob, Keys.spiritStateKey, state);
         PersistentDataAPI.setLong(mob, Keys.despawnKey, System.currentTimeMillis() + SpiritUtils.random((long) (definition.getTier() * 60L * 0.75), definition.getTier() * 60 * SpiritUtils.random(1, 3)) * 1000);
@@ -100,7 +98,6 @@ public class Spirit extends AbstractCustomMob<Allay> {
         
         if (PersistentDataAPI.hasLong(allay, Keys.despawnKey) && System.currentTimeMillis() >= PersistentDataAPI.getLong(allay, Keys.despawnKey)) {
             ParticleUtils.passOnAnimation(location);
-            getSpiritEntityManager().entityCollection.remove(allay);
             allay.remove();
         }
     }
@@ -111,7 +108,6 @@ public class Spirit extends AbstractCustomMob<Allay> {
         final ItemStack toDrop = ItemStacks.SU_ECTOPLASM.clone();
         toDrop.setAmount(definition.getTier() + 1);
         event.getDrops().add(toDrop);
-        getSpiritEntityManager().entityCollection.remove(event.getEntity());
     }
 
     @Override
@@ -137,7 +133,6 @@ public class Spirit extends AbstractCustomMob<Allay> {
         if (slimefunItem != null && slimefunItem.getId().equals(ItemStacks.SU_SPIRIT_NET.getItemId())) {
             if (new Random().nextInt(1,100) <= SpiritUtils.getTierChance(tier)) {
                 ParticleUtils.catchAnimation(entity.getLocation());
-                getSpiritEntityManager().entityCollection.remove((LivingEntity) entity);
                 entity.remove();
                 PlayerUtils.addOrDropItem(player, SpiritUtils.spiritItem(PersistentDataAPI.getString(entity, Keys.spiritStateKey), this.definition));
                 PlayerUtils.learnKnowledgePiece(player, type, 1);
@@ -160,7 +155,6 @@ public class Spirit extends AbstractCustomMob<Allay> {
             item.subtract();
         } else if (item.getType() == Material.GLASS_BOTTLE && item.getItemMeta().getPersistentDataContainer().isEmpty()) {
             ParticleUtils.bottleAnimation(entity.getLocation());
-            getSpiritEntityManager().entityCollection.remove((LivingEntity) entity);
             entity.remove();
             item.subtract();
             PlayerUtils.addOrDropItem(player, ItemStacks.SU_SPIRIT_BOTTLE);

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
@@ -62,7 +62,7 @@ public class Spirit extends AbstractCustomMob<Allay> {
         }
 
         final Allay mob = world.spawn(loc, this.getClazz());
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob);
+        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
         SpiritUtils.spiritIdMap.put(mob.getEntityId(), mob);
         PersistentDataAPI.setString(mob, Keys.entityKey, this.getId());
         PersistentDataAPI.setString(mob, Keys.spiritStateKey, state);

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/Spirit.java
@@ -2,9 +2,7 @@ package me.justahuman.spiritsunchained.implementation.mobs;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
-
 import lombok.Getter;
-
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
@@ -12,12 +10,10 @@ import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
 import me.justahuman.spiritsunchained.utils.PlayerUtils;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -32,8 +28,6 @@ import org.bukkit.potion.PotionEffectType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Objects;
-import java.util.Random;
 
 public class Spirit extends AbstractCustomMob<Allay> {
 
@@ -50,10 +44,9 @@ public class Spirit extends AbstractCustomMob<Allay> {
     @Override
     @Nonnull
     public final Allay spawn(@Nonnull Location loc, @Nonnull World world, String reason, String revealState) {
-        final double health = this.getMaxHealth()*definition.getTier();
         final String state;
         if (reason.equals("Natural")) {
-            state = definition.getStates().get(new Random().nextInt(definition.getStates().size()));
+            state = definition.getStates().get(SpiritUtils.random(0, definition.getStates().size()));
         } else if (reason.equals("Reveal")) {
             state = revealState;
         } else {
@@ -64,10 +57,8 @@ public class Spirit extends AbstractCustomMob<Allay> {
         SpiritsUnchained.getSpiritEntityManager().entitySet.add(mob.getUniqueId());
         PersistentDataAPI.setString(mob, Keys.entityKey, this.getId());
         PersistentDataAPI.setString(mob, Keys.spiritStateKey, state);
-        PersistentDataAPI.setLong(mob, Keys.despawnKey, System.currentTimeMillis() + SpiritUtils.random((long) (definition.getTier() * 60L * 0.75), definition.getTier() * 60 * SpiritUtils.random(1, 3)) * 1000);
-
-        Objects.requireNonNull(mob.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(health);
-        mob.setHealth(health);
+        PersistentDataAPI.setLong(mob, Keys.despawnKey, System.currentTimeMillis() + SpiritUtils.random((int) (definition.getTier() * 60 * 0.75), definition.getTier() * 60 * SpiritUtils.random(1, 3)) * 1000L);
+        
         mob.setRemoveWhenFarAway(true);
         mob.setCanPickupItems(false);
 
@@ -131,7 +122,7 @@ public class Spirit extends AbstractCustomMob<Allay> {
         }
         SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
         if (slimefunItem != null && slimefunItem.getId().equals(ItemStacks.SU_SPIRIT_NET.getItemId())) {
-            if (new Random().nextInt(1,100) <= SpiritUtils.getTierChance(tier)) {
+            if (SpiritUtils.chance(SpiritUtils.getTierChance(tier))) {
                 ParticleUtils.catchAnimation(entity.getLocation());
                 entity.remove();
                 PlayerUtils.addOrDropItem(player, SpiritUtils.spiritItem(PersistentDataAPI.getString(entity, Keys.spiritStateKey), this.definition));
@@ -141,7 +132,7 @@ public class Spirit extends AbstractCustomMob<Allay> {
             }
             item.subtract();
         } else if(slimefunItem != null && slimefunItem.getId().equals(ItemStacks.SU_SPIRIT_BOOK.getItemId())) {
-            if (new Random().nextInt(1, 100) <= SpiritUtils.getTierChance(tier)) {
+            if (SpiritUtils.chance(SpiritUtils.getTierChance(tier))) {
                 if (!PlayerUtils.hasKnowledgePiece(player, type, 2)) {
                     PlayerUtils.addOrDropItem(player, SpiritUtils.getFilledBook(this.definition));
                     PlayerUtils.learnKnowledgePiece(player, type, 2);

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
@@ -42,7 +42,7 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
     @Override
     public Allay spawn(@Nonnull Location loc, @Nonnull World world, String reason, String type) {
         final Allay mob = world.spawn(loc, this.getClazz());
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
+        SpiritsUnchained.getSpiritEntityManager().entitySet.add(mob.getUniqueId());
         final SpiritDefinition definition = SpiritsUnchained.getSpiritsManager().getSpiritMap().get(EntityType.valueOf(type));
         final String state;
 
@@ -93,7 +93,7 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
         ParticleUtils.spawnParticleRadius(location, Particle.SPELL_INSTANT, 0.1, 5, "Spirit");
         if (PersistentDataAPI.hasLong(allay, Keys.despawnKey) && System.currentTimeMillis() >= PersistentDataAPI.getLong(allay, Keys.despawnKey)) {
             ParticleUtils.passOnAnimation(location);
-            getSpiritEntityManager().entityCollection.remove(allay.getUniqueId());
+            getSpiritEntityManager().entitySet.remove(allay.getUniqueId());
             allay.remove();
         }
     }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
@@ -44,7 +44,7 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
     public Allay spawn(@Nonnull Location loc, @Nonnull World world, String reason, String type) {
         final Allay mob = world.spawn(loc, this.getClazz());
         SpiritUtils.spiritIdMap.put(mob.getEntityId(), mob);
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob);
+        SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
         final SpiritDefinition definition = SpiritsUnchained.getSpiritsManager().getSpiritMap().get(EntityType.valueOf(type));
         final String state;
 

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
@@ -18,7 +18,6 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -43,7 +42,6 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
     @Override
     public Allay spawn(@Nonnull Location loc, @Nonnull World world, String reason, String type) {
         final Allay mob = world.spawn(loc, this.getClazz());
-        SpiritUtils.spiritIdMap.put(mob.getEntityId(), mob);
         SpiritsUnchained.getSpiritEntityManager().entityCollection.add(mob.getUniqueId());
         final SpiritDefinition definition = SpiritsUnchained.getSpiritsManager().getSpiritMap().get(EntityType.valueOf(type));
         final String state;
@@ -95,7 +93,7 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
         ParticleUtils.spawnParticleRadius(location, Particle.SPELL_INSTANT, 0.1, 5, "Spirit");
         if (PersistentDataAPI.hasLong(allay, Keys.despawnKey) && System.currentTimeMillis() >= PersistentDataAPI.getLong(allay, Keys.despawnKey)) {
             ParticleUtils.passOnAnimation(location);
-            getSpiritEntityManager().entityCollection.remove(allay);
+            getSpiritEntityManager().entityCollection.remove(allay.getUniqueId());
             allay.remove();
         }
     }
@@ -109,7 +107,6 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
             return;
         }
         event.setShouldPlayDeathSound(false);
-        getSpiritEntityManager().entityCollection.remove(allay);
     }
 
     @Override
@@ -126,13 +123,11 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
 
         SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
         if (slimefunItem != null && slimefunItem.getId().equals(ItemStacks.SU_SPIRIT_NET.getItemId())) {
-            getSpiritEntityManager().entityCollection.remove((LivingEntity) entity);
             ParticleUtils.catchAnimation(entity.getLocation());
             entity.remove();
             item.setAmount(item.getAmount() - 1);
             player.getInventory().addItem(ItemStacks.SU_UNIDENTIFIED_SPIRIT);
         } else if (item.getType() == Material.GLASS_BOTTLE && item.getItemMeta().getPersistentDataContainer().isEmpty()) {
-            getSpiritEntityManager().entityCollection.remove((LivingEntity) entity);
             ParticleUtils.bottleAnimation(entity.getLocation());
             entity.remove();
             item.setAmount(item.getAmount() - 1);
@@ -150,7 +145,6 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
     @ParametersAreNonnullByDefault
     public void reveal(Allay allay, Player player) {
         SpiritsUnchained.getSpiritEntityManager().getCustomClass(null, PersistentDataAPI.getString(allay, Keys.spiritTypeKey)).spawn(allay.getLocation(), allay.getWorld(), "Reveal", PersistentDataAPI.getString(allay, Keys.spiritStateKey));
-        getSpiritEntityManager().entityCollection.remove(allay);
         allay.remove();
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/mobs/UnIdentifiedSpirit.java
@@ -2,19 +2,16 @@ package me.justahuman.spiritsunchained.implementation.mobs;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
-
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.Keys;
-
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.World;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Allay;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
@@ -29,8 +26,6 @@ import org.bukkit.potion.PotionEffectType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Objects;
-import java.util.Random;
 
 public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
 
@@ -47,7 +42,7 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
         final String state;
 
         if (reason.equals("Natural")) {
-            state = definition.getStates().get(new Random().nextInt(definition.getStates().size()));
+            state = definition.getStates().get(SpiritUtils.random(0, definition.getStates().size()));
         } else {
             state = reason;
         }
@@ -62,10 +57,8 @@ public class UnIdentifiedSpirit extends AbstractCustomMob<Allay> {
         PersistentDataAPI.setString(mob, Keys.spiritStateKey, state);
         PersistentDataAPI.setString(mob, Keys.spiritTypeKey, type);
         PersistentDataAPI.setBoolean(mob, Keys.spiritIdentified, false);
-        PersistentDataAPI.setLong(mob, Keys.despawnKey, System.currentTimeMillis() + SpiritUtils.random((long) (definition.getTier() * 60L * 0.75), definition.getTier() * 60L * SpiritUtils.random(1, 3)) * 1000);
-    
-        Objects.requireNonNull(mob.getAttribute(Attribute.GENERIC_MAX_HEALTH)).setBaseValue(this.getMaxHealth());
-        mob.setHealth(this.getMaxHealth());
+        PersistentDataAPI.setLong(mob, Keys.despawnKey, System.currentTimeMillis() + SpiritUtils.random((int) (definition.getTier() * 60L * 0.75), definition.getTier() * 60 * SpiritUtils.random(1, 3)) * 1000L);
+        
         mob.setRemoveWhenFarAway(true);
         mob.setCanPickupItems(false);
 

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/SpiritualAltarPiece.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/SpiritualAltarPiece.java
@@ -8,7 +8,6 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/Tier1Altar.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/Tier1Altar.java
@@ -14,7 +14,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.justahuman.spiritsunchained.slimefun.Groups;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -72,55 +71,55 @@ public class Tier1Altar extends SlimefunItem {
         return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlayerPlace(@Nonnull BlockPlaceEvent e) {
-                final Block b = e.getBlockPlaced();
-                BlockStorage.addBlockInfo(b, "particle", "2");
-                BlockStorage.addBlockInfo(b, "multiplier", "1.0");
-                if (isComplete(b)) {
-                    BlockStorage.addBlockInfo(b, complete, "true");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.1"));
+            public void onPlayerPlace(@Nonnull BlockPlaceEvent event) {
+                final Block block = event.getBlockPlaced();
+                BlockStorage.addBlockInfo(block, "particle", "2");
+                BlockStorage.addBlockInfo(block, "multiplier", "1.0");
+                if (isComplete(block)) {
+                    BlockStorage.addBlockInfo(block, complete, "true");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.1"));
                 } else {
-                    BlockStorage.addBlockInfo(b, complete, "false");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.complete_prompt"));
+                    BlockStorage.addBlockInfo(block, complete, "false");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.complete_prompt"));
                 }
             }
         };
     }
 
     private BlockUseHandler onUse() {
-        return e -> {
-            final Block b = e.getClickedBlock().get();
-            if (BlockStorage.getLocationInfo(b.getLocation(), complete).equals("false")) {
-                if (isComplete(b)) {
-                    BlockStorage.addBlockInfo(b, complete, "true");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.1"));
+        return event -> {
+            final Block block = event.getClickedBlock().isPresent() ? event.getClickedBlock().get() : null;
+            if (block != null && BlockStorage.getLocationInfo(block.getLocation(), complete).equals("false")) {
+                if (isComplete(block)) {
+                    BlockStorage.addBlockInfo(block, complete, "true");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.1"));
                 } else {
-                    BlockStorage.addBlockInfo(b, complete, "false");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.not_completed"));
+                    BlockStorage.addBlockInfo(block, complete, "false");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.not_completed"));
                 }
             }
 
-            e.cancel();
+            event.cancel();
         };
     }
 
     private BlockBreakHandler onBreak() {
         return new BlockBreakHandler(false, false) {
             @Override
-            public void onPlayerBreak(@Nonnull BlockBreakEvent e, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
-                BlockStorage.addBlockInfo(e.getBlock(), complete, null);
-                BlockStorage.clearBlockInfo(e.getBlock());
-                e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.broken"));
+            public void onPlayerBreak(@Nonnull BlockBreakEvent event, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
+                BlockStorage.addBlockInfo(event.getBlock(), complete, null);
+                BlockStorage.clearBlockInfo(event.getBlock());
+                event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.broken"));
             }
         };
     }
 
-    private boolean isComplete(@Nonnull Block b) {
+    private boolean isComplete(@Nonnull Block block) {
 
         for (Map.Entry<Vector, Material> entry : blocks.entrySet()) {
             final Vector relative = entry.getKey();
             final Material relativeMaterial = entry.getValue();
-            final Block relativeBlock = b.getRelative(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
+            final Block relativeBlock = block.getRelative(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
             if (relativeBlock.getType() != relativeMaterial || !isAltarPiece(relativeBlock)) {
                 return false;
             }
@@ -129,12 +128,12 @@ public class Tier1Altar extends SlimefunItem {
         return true;
     }
 
-    private boolean isAltarPiece(@Nonnull Block b) {
-        if (BlockStorage.getLocationInfo(b.getLocation(), "id") == null) {
+    private boolean isAltarPiece(@Nonnull Block block) {
+        if (BlockStorage.getLocationInfo(block.getLocation(), "id") == null) {
             return false;
         }
 
-        return switch (BlockStorage.getLocationInfo(b.getLocation(), "id")) {
+        return switch (BlockStorage.getLocationInfo(block.getLocation(), "id")) {
             case "SU_CHARGED_QUARTZ_I", "SU_CHARGED_STAIRS_I", "SU_CHARGED_CORE_I" -> true;
             default -> false;
         };

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/Tier2Altar.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/Tier2Altar.java
@@ -14,7 +14,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.justahuman.spiritsunchained.slimefun.Groups;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -86,55 +85,55 @@ public class Tier2Altar extends SlimefunItem {
         return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlayerPlace(@Nonnull BlockPlaceEvent e) {
-                final Block b = e.getBlockPlaced();
-                BlockStorage.addBlockInfo(b, "particle", "4");
-                BlockStorage.addBlockInfo(b, "multiplier", "2.0");
-                if (isComplete(b)) {
-                    BlockStorage.addBlockInfo(b, complete, "true");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.2"));
+            public void onPlayerPlace(@Nonnull BlockPlaceEvent event) {
+                final Block block = event.getBlockPlaced();
+                BlockStorage.addBlockInfo(block, "particle", "4");
+                BlockStorage.addBlockInfo(block, "multiplier", "2.0");
+                if (isComplete(block)) {
+                    BlockStorage.addBlockInfo(block, complete, "true");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.2"));
                 } else {
-                    BlockStorage.addBlockInfo(b, complete, "false");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.complete_prompt"));
+                    BlockStorage.addBlockInfo(block, complete, "false");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.complete_prompt"));
                 }
             }
         };
     }
 
     private BlockUseHandler onUse() {
-        return e -> {
-            final Block b = e.getClickedBlock().get();
-            if (BlockStorage.getLocationInfo(b.getLocation(), complete).equals("false")) {
-                if (isComplete(b)) {
-                    BlockStorage.addBlockInfo(b, complete, "true");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.2"));
+        return event -> {
+            final Block block = event.getClickedBlock().isPresent() ? event.getClickedBlock().get() : null;
+            if (block != null && BlockStorage.getLocationInfo(block.getLocation(), complete).equals("false")) {
+                if (isComplete(block)) {
+                    BlockStorage.addBlockInfo(block, complete, "true");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.2"));
                 } else {
-                    BlockStorage.addBlockInfo(b, complete, "false");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.not_completed"));
+                    BlockStorage.addBlockInfo(block, complete, "false");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.not_completed"));
                 }
             }
-
-            e.cancel();
+        
+            event.cancel();
         };
     }
 
     private BlockBreakHandler onBreak() {
         return new BlockBreakHandler(false, false) {
             @Override
-            public void onPlayerBreak(@Nonnull BlockBreakEvent e, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
-                BlockStorage.addBlockInfo(e.getBlock(), complete, null);
-                BlockStorage.clearBlockInfo(e.getBlock());
-                e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.broken"));
+            public void onPlayerBreak(@Nonnull BlockBreakEvent event, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
+                BlockStorage.addBlockInfo(event.getBlock(), complete, null);
+                BlockStorage.clearBlockInfo(event.getBlock());
+                event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.broken"));
             }
         };
     }
 
-    private boolean isComplete(@Nonnull Block b) {
+    private boolean isComplete(@Nonnull Block block) {
 
         for (Map.Entry<Vector, Material> entry : blocks.entrySet()) {
             final Vector relative = entry.getKey();
             final Material relativeMaterial = entry.getValue();
-            final Block relativeBlock = b.getRelative(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
+            final Block relativeBlock = block.getRelative(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
             if (relativeBlock.getType() != relativeMaterial || !isAltarPiece(relativeBlock)) {
                 return false;
             }
@@ -143,12 +142,12 @@ public class Tier2Altar extends SlimefunItem {
         return true;
     }
 
-    private boolean isAltarPiece(@Nonnull Block b) {
-        if (BlockStorage.getLocationInfo(b.getLocation(), "id") == null) {
+    private boolean isAltarPiece(@Nonnull Block block) {
+        if (BlockStorage.getLocationInfo(block.getLocation(), "id") == null) {
             return false;
         }
 
-        return switch (BlockStorage.getLocationInfo(b.getLocation(), "id")) {
+        return switch (BlockStorage.getLocationInfo(block.getLocation(), "id")) {
             case "SU_CHARGED_QUARTZ_II", "SU_CHARGED_STAIRS_II", "SU_CHARGED_PILLAR_II", "SU_CHARGED_CORE_II" -> true;
             default -> false;
         };

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/Tier3Altar.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/multiblocks/Tier3Altar.java
@@ -14,7 +14,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.justahuman.spiritsunchained.slimefun.Groups;
 import me.justahuman.spiritsunchained.slimefun.ItemStacks;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -107,55 +106,55 @@ public class Tier3Altar extends SlimefunItem {
         return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlayerPlace(@Nonnull BlockPlaceEvent e) {
-                final Block b = e.getBlockPlaced();
-                BlockStorage.addBlockInfo(b, "particle", "8");
-                BlockStorage.addBlockInfo(b, "multiplier", "4.0");
-                if (isComplete(b)) {
-                    BlockStorage.addBlockInfo(b, complete, "true");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.3"));
+            public void onPlayerPlace(@Nonnull BlockPlaceEvent event) {
+                final Block block = event.getBlockPlaced();
+                BlockStorage.addBlockInfo(block, "particle", "8");
+                BlockStorage.addBlockInfo(block, "multiplier", "4.0");
+                if (isComplete(block)) {
+                    BlockStorage.addBlockInfo(block, complete, "true");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.3"));
                 } else {
-                    BlockStorage.addBlockInfo(b, complete, "false");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.complete_prompt"));
+                    BlockStorage.addBlockInfo(block, complete, "false");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.complete_prompt"));
                 }
             }
         };
     }
 
     private BlockUseHandler onUse() {
-        return e -> {
-            final Block b = e.getClickedBlock().get();
-            if (BlockStorage.getLocationInfo(b.getLocation(), complete).equals("false")) {
-                if (isComplete(b)) {
-                    BlockStorage.addBlockInfo(b, complete, "true");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.3"));
+        return event -> {
+            final Block block = event.getClickedBlock().isPresent() ? event.getClickedBlock().get() : null;
+            if (block != null && BlockStorage.getLocationInfo(block.getLocation(), complete).equals("false")) {
+                if (isComplete(block)) {
+                    BlockStorage.addBlockInfo(block, complete, "true");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.completed.3"));
                 } else {
-                    BlockStorage.addBlockInfo(b, complete, "false");
-                    e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.not_completed"));
+                    BlockStorage.addBlockInfo(block, complete, "false");
+                    event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.not_completed"));
                 }
             }
-
-            e.cancel();
+        
+            event.cancel();
         };
     }
 
     private BlockBreakHandler onBreak() {
         return new BlockBreakHandler(false, false) {
             @Override
-            public void onPlayerBreak(@Nonnull BlockBreakEvent e, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
-                BlockStorage.addBlockInfo(e.getBlock(), complete, null);
-                BlockStorage.clearBlockInfo(e.getBlock());
-                e.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.broken"));
+            public void onPlayerBreak(@Nonnull BlockBreakEvent event, @Nonnull ItemStack item, @Nonnull List<ItemStack> drops) {
+                BlockStorage.addBlockInfo(event.getBlock(), complete, null);
+                BlockStorage.clearBlockInfo(event.getBlock());
+                event.getPlayer().sendMessage(SpiritUtils.getTranslation("messages.altar.broken"));
             }
         };
     }
 
-    private boolean isComplete(@Nonnull Block b) {
+    private boolean isComplete(@Nonnull Block block) {
 
         for (Map.Entry<Vector, Material> entry : blocks.entrySet()) {
             final Vector relative = entry.getKey();
             final Material relativeMaterial = entry.getValue();
-            final Block relativeBlock = b.getRelative(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
+            final Block relativeBlock = block.getRelative(relative.getBlockX(), relative.getBlockY(), relative.getBlockZ());
             if (relativeBlock.getType() != relativeMaterial || !isAltarPiece(relativeBlock)) {
                 return false;
             }
@@ -164,12 +163,12 @@ public class Tier3Altar extends SlimefunItem {
         return true;
     }
 
-    private boolean isAltarPiece(@Nonnull Block b) {
-        if (BlockStorage.getLocationInfo(b.getLocation(), "id") == null) {
+    private boolean isAltarPiece(@Nonnull Block block) {
+        if (BlockStorage.getLocationInfo(block.getLocation(), "id") == null) {
             return false;
         }
 
-        return switch (BlockStorage.getLocationInfo(b.getLocation(), "id")) {
+        return switch (BlockStorage.getLocationInfo(block.getLocation(), "id")) {
             case "SU_CHARGED_QUARTZ_III", "SU_SMOOTH_CHARGED_QUARTZ_III", "SU_CHARGED_PILLAR_III", "SU_SMOOTH_CHARGED_STAIRS_III", "SU_CHARGED_CORE_III" -> true;
             default -> false;
         };

--- a/src/main/java/me/justahuman/spiritsunchained/implementation/tools/SpiritRune.java
+++ b/src/main/java/me/justahuman/spiritsunchained/implementation/tools/SpiritRune.java
@@ -1,6 +1,5 @@
 package me.justahuman.spiritsunchained.implementation.tools;
 
-
 import io.github.bakedlibs.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
@@ -14,7 +13,6 @@ import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import net.kyori.adventure.text.Component;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Particle;
 import org.bukkit.entity.Entity;
@@ -44,12 +42,12 @@ public class SpiritRune extends SimpleSlimefunItem<ItemDropHandler> {
     @Nonnull
     @Override
     public ItemDropHandler getItemHandler() {
-        return (e, p, item) -> {
+        return (event, player, item) -> {
             if (isItem(item.getItemStack())) {
-                if (canUse(p, true)) {
+                if (canUse(player, true)) {
                     Slimefun.runSync(() -> {
                         try {
-                            addSpiritTag(p, item);
+                            addSpiritTag(player, item);
                         } catch (Exception x) {
                             error("An Exception occurred while trying to apply an Spirit Rune", x);
                         }
@@ -64,14 +62,14 @@ public class SpiritRune extends SimpleSlimefunItem<ItemDropHandler> {
     }
 
 
-    private void addSpiritTag(@Nonnull Player p, @Nonnull Item rune) {
+    private void addSpiritTag(@Nonnull Player player, @Nonnull Item rune) {
         // Being sure the entity is still valid and not picked up or whatsoever.
         if (!rune.isValid()) {
             return;
         }
 
-        final Location l = rune.getLocation();
-        final Collection<Entity> entities = l.getWorld().getNearbyEntities(l, RANGE, RANGE, RANGE, this::findCompatibleItem);
+        final Location location = rune.getLocation();
+        final Collection<Entity> entities = location.getWorld().getNearbyEntities(location, RANGE, RANGE, RANGE, this::findCompatibleItem);
         final Optional<Entity> optional = entities.stream().findFirst();
 
         if (optional.isPresent()) {
@@ -79,39 +77,39 @@ public class SpiritRune extends SimpleSlimefunItem<ItemDropHandler> {
             final ItemStack itemStack = item.getItemStack();
             final ItemStack runeStack = rune.getItemStack();
             if (!itemStack.getType().name().endsWith("HELMET")) {
-                p.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.not_helmet"));
+                player.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.not_helmet"));
                 return;
             }
 
             if (itemStack.getAmount() == 1 && runeStack.getAmount() == 1) {
                 // This lightning is just an effect, it deals no damage.
-                l.getWorld().strikeLightningEffect(l);
+                location.getWorld().strikeLightningEffect(location);
 
                 Slimefun.runSync(() -> {
                     // Being sure entities are still valid and not picked up or whatsoever.
                     if (rune.isValid() && runeStack.getAmount() == 1 && item.isValid() && itemStack.getAmount() == 1 && !PersistentDataAPI.hasByte(itemStack.getItemMeta(), Keys.imbuedKey)) {
 
-                        l.getWorld().spawnParticle(Particle.CRIT_MAGIC, l, 1);
-                        l.getWorld().playSound(l, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1F);
+                        location.getWorld().spawnParticle(Particle.CRIT_MAGIC, location, 1);
+                        location.getWorld().playSound(location, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1F);
 
                         item.remove();
                         rune.remove();
 
-                        setImbued(itemStack,p);
-                        l.getWorld().dropItemNaturally(l, itemStack);
+                        setImbued(itemStack);
+                        location.getWorld().dropItemNaturally(location, itemStack);
 
-                        p.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.imbued"));
+                        player.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.imbued"));
                     }
                 }, 10L);
             } else if (itemStack.getAmount() != 1) {
-                p.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.multiple_helmets"));
+                player.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.multiple_helmets"));
             } else if (runeStack.getAmount() != 1) {
-                p.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.multiple_runes"));
+                player.sendMessage(SpiritUtils.getTranslation("messages.spirit_rune.multiple_runes"));
             }
         }
     }
 
-    public static void setImbued(@Nullable ItemStack item, Player p) {
+    public static void setImbued(@Nullable ItemStack item) {
         if (item != null && item.getType() != Material.AIR && !PersistentDataAPI.hasByte(item.getItemMeta(), Keys.imbuedKey)) {
             final ItemMeta meta = item.getItemMeta();
             PersistentDataAPI.setByte(meta, Keys.imbuedKey, (byte) 2);

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/IdentifyingGlassListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/IdentifyingGlassListener.java
@@ -2,7 +2,6 @@ package me.justahuman.spiritsunchained.listeners;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
@@ -16,6 +16,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityBreedEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -28,7 +29,7 @@ import java.util.Set;
 
 public class PassOnListeners implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onItemClick(InventoryClickEvent clickEvent) {
         final ItemStack clickingWith = clickEvent.getCursor();
         final ItemStack clicking = clickEvent.getCurrentItem();
@@ -62,7 +63,7 @@ public class PassOnListeners implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBreedEntity(EntityBreedEvent event) {
         final LivingEntity bredEntity = event.getEntity();
         if (!(event.getBreeder() instanceof Player player) || !SpiritsUnchained.getSpiritsManager().getGoalRequirements().containsKey(bredEntity.getType())) {
@@ -72,7 +73,7 @@ public class PassOnListeners implements Listener {
         onSpecialInteract(player, bredEntity, "Breed");
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityKill(EntityDeathEvent event) {
         final LivingEntity killedEntity = event.getEntity();
         final Player player = killedEntity.getKiller();

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
@@ -3,7 +3,6 @@ package me.justahuman.spiritsunchained.listeners;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
-
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.spirits.Goal;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
@@ -11,7 +10,6 @@ import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
 import me.justahuman.spiritsunchained.utils.PlayerUtils;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
-
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.EntityType;
@@ -26,7 +24,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 
 public class PassOnListeners implements Listener {
@@ -121,12 +118,12 @@ public class PassOnListeners implements Listener {
         final String tierPath = "tiered." + tier;
         final boolean override = rewards.contains(overridePath);
         final List<String> drops = override ? rewards.getStringList(overridePath + ".rewards") : rewards.getStringList(tierPath + ".rewards");
-        final String drop = drops.get(new Random().nextInt(drops.size()));
+        final String drop = drops.get(SpiritUtils.random(0, drops.size()));
         final SlimefunItem sfDrop = SlimefunItem.getById(drop);
         final int min = override ? rewards.getInt(overridePath + ".min") : rewards.getInt(tierPath + ".min");
-        final int max = override ? rewards.getInt(overridePath + ".max") : rewards.getInt(tierPath + ".max");
+        final int max = (override ? rewards.getInt(overridePath + ".max"): rewards.getInt(tierPath + ".max")) + 1;
         toDrop = sfDrop == null ? new ItemStack(Material.valueOf(drop)) : sfDrop.getItem().clone();
-        toDrop.setAmount(new Random().nextInt(min, max + 1));
+        toDrop.setAmount(SpiritUtils.random(min, max));
         PlayerUtils.addOrDropItem(player, toDrop);
         ParticleUtils.passOnAnimation(player.getLocation());
         player.sendMessage(SpiritUtils.getTranslation("messages.spirits.pass_on").replace("{tier_color}", String.valueOf(SpiritUtils.tierColor(tier))).replace("{spirit_name}", ChatUtils.humanize(type.name())));

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
@@ -1,12 +1,10 @@
 package me.justahuman.spiritsunchained.listeners;
 
-import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 
 import me.justahuman.spiritsunchained.SpiritsUnchained;
-import me.justahuman.spiritsunchained.implementation.mobs.AbstractCustomMob;
 import me.justahuman.spiritsunchained.spirits.Goal;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.Keys;
@@ -16,8 +14,6 @@ import me.justahuman.spiritsunchained.utils.SpiritUtils;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.entity.Allay;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PassOnListeners.java
@@ -1,10 +1,12 @@
 package me.justahuman.spiritsunchained.listeners;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 
 import me.justahuman.spiritsunchained.SpiritsUnchained;
+import me.justahuman.spiritsunchained.implementation.mobs.AbstractCustomMob;
 import me.justahuman.spiritsunchained.spirits.Goal;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.Keys;
@@ -14,6 +16,8 @@ import me.justahuman.spiritsunchained.utils.SpiritUtils;
 
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Allay;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerArmorListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerArmorListener.java
@@ -1,0 +1,36 @@
+package me.justahuman.spiritsunchained.listeners;
+
+import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
+import lombok.Getter;
+import me.justahuman.spiritsunchained.utils.SpiritUtils;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class PlayerArmorListener implements Listener {
+    @Getter
+    private static final List<UUID> canSeeUUIDList = new ArrayList<>();
+    
+    @EventHandler
+    public void onPlayerArmorChange(PlayerArmorChangeEvent event) {
+        final Player player = event.getPlayer();
+        final ItemStack newItem = event.getNewItem();
+        final PlayerArmorChangeEvent.SlotType slotType = event.getSlotType();
+        
+        if (slotType != PlayerArmorChangeEvent.SlotType.HEAD) {
+            return;
+        }
+        
+        if (!SpiritUtils.imbuedCheck(newItem)) {
+            canSeeUUIDList.remove(player.getUniqueId());
+            return;
+        }
+        
+        canSeeUUIDList.add(player.getUniqueId());
+    }
+}

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerArmorListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerArmorListener.java
@@ -1,22 +1,28 @@
 package me.justahuman.spiritsunchained.listeners;
 
 import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
+import com.destroystokyo.paper.event.player.PlayerPostRespawnEvent;
 import lombok.Getter;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockDispenseArmorEvent;
+import org.bukkit.event.player.PlayerItemBreakEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 public class PlayerArmorListener implements Listener {
     @Getter
-    private static final List<UUID> canSeeUUIDList = new ArrayList<>();
+    private static final Set<UUID> canSeeUUIDList = new HashSet<>();
     
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerArmorChange(PlayerArmorChangeEvent event) {
         final Player player = event.getPlayer();
         final ItemStack newItem = event.getNewItem();
@@ -32,5 +38,46 @@ public class PlayerArmorListener implements Listener {
         }
         
         canSeeUUIDList.add(player.getUniqueId());
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockDispenseArmor(BlockDispenseArmorEvent event) {
+        final Entity entity = event.getTargetEntity();
+        final ItemStack newItem = event.getItem();
+        
+        if (!(entity instanceof Player player)) {
+            return;
+        }
+    
+        if (!SpiritUtils.imbuedCheck(newItem)) {
+            canSeeUUIDList.remove(player.getUniqueId());
+            return;
+        }
+    
+        canSeeUUIDList.add(player.getUniqueId());
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onItemBreak(PlayerItemBreakEvent event) {
+        final Player player = event.getPlayer();
+        final ItemStack brokenItem = event.getBrokenItem();
+        
+        if (SpiritUtils.imbuedCheck(brokenItem)) {
+            canSeeUUIDList.remove(player.getUniqueId());
+        }
+    }
+    
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPostRespawn(PlayerPostRespawnEvent event) {
+        updatePlayer(event.getPlayer());
+    }
+    
+    public static void updatePlayer(Player player) {
+        final ItemStack helmetItem = player.getInventory().getItem(EquipmentSlot.HEAD);
+        if (SpiritUtils.imbuedCheck(helmetItem)) {
+            canSeeUUIDList.add(player.getUniqueId());
+        } else {
+            canSeeUUIDList.remove(player.getUniqueId());
+        }
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
@@ -60,7 +60,7 @@ public class PlayerClickListener implements Listener {
             final List<Entity> lookingAt = SpiritUtils.getLookingList(player);
             for (Entity entity : lookingAt) {
                 final AbstractCustomMob<?> maybe = SpiritsUnchained.getSpiritEntityManager().getCustomClass(entity, null);
-                if (entity instanceof Allay && maybe != null && player.getLocation().distance(entity.getLocation()) < 4) {
+                if (entity instanceof Allay && maybe != null && player.getLocation().distanceSquared(entity.getLocation()) < Math.pow(4, 2)) {
                     if (!Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.INTERACT_ENTITY)) {
                         player.sendMessage(SpiritUtils.getTranslation("messages.general.no_permission_entity_interact"));
                         return;
@@ -74,24 +74,22 @@ public class PlayerClickListener implements Listener {
     }
 
     private boolean rightClick(Player player, ItemStack item) {
-        if (item.getType() == Material.FIREWORK_STAR) {
-            if (SpiritUtils.isSpiritItem(item)) {
-                if (player.isSneaking()) {
-                    ItemMeta meta = item.getItemMeta();
-                    PersistentDataAPI.setBoolean(meta, Keys.spiritLocked, !PersistentDataAPI.getBoolean(meta, Keys.spiritLocked));
-                    item.setItemMeta(meta);
-                    SpiritUtils.updateSpiritItemProgress(item, 0);
-                    player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent((PersistentDataAPI.getBoolean(meta, Keys.spiritLocked) ? SpiritUtils.getTranslation("messages.spirits.locked") : SpiritUtils.getTranslation("messages.spirits.unlocked"))));
-                    return true;
-                }
-                final String type = PersistentDataAPI.getString(item.getItemMeta(), Keys.spiritItemKey);
-                final Map<String, Object> traitInfo = SpiritUtils.getTraitInfo(SpiritsUnchained.getSpiritsManager().getSpiritMap().get(EntityType.valueOf(type)).getTrait());
-                final String message = SpiritTraits.useTrait(player, traitInfo, item);
-                if (message != null) {
-                    player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColors.color(message)));
-                }
+        if (item.getType() == Material.FIREWORK_STAR && SpiritUtils.isSpiritItem(item)) {
+            if (player.isSneaking()) {
+                ItemMeta meta = item.getItemMeta();
+                PersistentDataAPI.setBoolean(meta, Keys.spiritLocked, !PersistentDataAPI.getBoolean(meta, Keys.spiritLocked));
+                item.setItemMeta(meta);
+                SpiritUtils.updateSpiritItemProgress(item, 0);
+                player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent((PersistentDataAPI.getBoolean(meta, Keys.spiritLocked) ? SpiritUtils.getTranslation("messages.spirits.locked") : SpiritUtils.getTranslation("messages.spirits.unlocked"))));
                 return true;
             }
+            final String type = PersistentDataAPI.getString(item.getItemMeta(), Keys.spiritItemKey);
+            final Map<String, Object> traitInfo = SpiritUtils.getTraitInfo(SpiritsUnchained.getSpiritsManager().getSpiritMap().get(EntityType.valueOf(type)).getTrait());
+            final String message = SpiritTraits.useTrait(player, traitInfo, item);
+            if (message != null) {
+                player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(ChatColors.color(message)));
+            }
+            return true;
         }
         if (item.getType() == Material.BAMBOO && SpiritUtils.useSpiritItem(player, EntityType.PANDA, null)) {
             player.getWorld().playSound(player.getLocation(), Sound.ENTITY_PLAYER_BURP, 1, 1);

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PlayerClickListener implements Listener {
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerClick(PlayerInteractEvent e) {
         final Player player = e.getPlayer();
         if (e.getAction() == Action.LEFT_CLICK_AIR && player.isSneaking()) {

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerClickListener.java
@@ -60,7 +60,7 @@ public class PlayerClickListener implements Listener {
             final List<Entity> lookingAt = SpiritUtils.getLookingList(player);
             for (Entity entity : lookingAt) {
                 final AbstractCustomMob<?> maybe = SpiritsUnchained.getSpiritEntityManager().getCustomClass(entity, null);
-                if (entity instanceof Allay && maybe != null && player.getLocation().distanceSquared(entity.getLocation()) < Math.pow(4, 2)) {
+                if (entity instanceof Allay && maybe != null && player.getLocation().distanceSquared(entity.getLocation()) < Math.pow(4, 2) && e.getHand() != null) {
                     if (!Slimefun.getProtectionManager().hasPermission(player, player.getLocation(), Interaction.INTERACT_ENTITY)) {
                         player.sendMessage(SpiritUtils.getTranslation("messages.general.no_permission_entity_interact"));
                         return;

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerJoinListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerJoinListener.java
@@ -4,13 +4,15 @@ import me.justahuman.spiritsunchained.SpiritsUnchained;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 
 public class PlayerJoinListener implements Listener {
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerJoin(PlayerJoinEvent event) {
         final Player player = event.getPlayer();
+        PlayerArmorListener.updatePlayer(player);
         for (LivingEntity entity : SpiritsUnchained.getSpiritEntityManager().getCustomLivingEntities()) {
             if (player.canSee(entity)) {
                 player.hideEntity(SpiritsUnchained.getInstance(), entity);

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerJoinListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerJoinListener.java
@@ -1,0 +1,20 @@
+package me.justahuman.spiritsunchained.listeners;
+
+import me.justahuman.spiritsunchained.SpiritsUnchained;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class PlayerJoinListener implements Listener {
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        final Player player = event.getPlayer();
+        for (LivingEntity entity : SpiritsUnchained.getSpiritEntityManager().entityCollection) {
+            if (player.canSee(entity)) {
+                player.hideEntity(SpiritsUnchained.getInstance(), entity);
+            }
+        }
+    }
+}

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerJoinListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerJoinListener.java
@@ -11,7 +11,7 @@ public class PlayerJoinListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         final Player player = event.getPlayer();
-        for (LivingEntity entity : SpiritsUnchained.getSpiritEntityManager().entityCollection) {
+        for (LivingEntity entity : SpiritsUnchained.getSpiritEntityManager().getCustomLivingEntities()) {
             if (player.canSee(entity)) {
                 player.hideEntity(SpiritsUnchained.getInstance(), entity);
             }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -41,7 +41,7 @@ public class PlayerReleaseSpiritListener implements Listener {
 
         final SpiritDefinition definition = SpiritsUnchained.getSpiritsManager().getSpiritMap().get(type);
         final int chance = ThreadLocalRandom.current().nextInt(1, 100);
-        if (PlayerArmorListener.getCanSeeUUIDList().contains(player.getUniqueId()) && chance <= 10/definition.getTier() && SpiritUtils.getNearbySpirits(killedEntity.getLocation()).size() < SpiritUtils.getPlayerCap() && (spawnerSpirits || ! killedEntity.fromMobSpawner()) && ! config.getStringList("options.disabled-worlds").contains(killedEntity.getWorld().getName())) {
+        if (PlayerArmorListener.getCanSeeUUIDList().contains(player.getUniqueId()) && chance <= 10/definition.getTier() && SpiritUtils.getNearbySpirits(killedEntity.getLocation(), 64).size() < SpiritUtils.getPlayerCap() && (spawnerSpirits || ! killedEntity.fromMobSpawner()) && ! config.getStringList("options.disabled-worlds").contains(killedEntity.getWorld().getName())) {
             spirit.spawn(killedEntity.getLocation(), killedEntity.getWorld(), "Hostile", null);
         }
     }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -20,7 +20,7 @@ import java.util.UUID;
 
 public class PlayerReleaseSpiritListener implements Listener {
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void playerReleaseSpirit(EntityDeathEvent e) {
         final SpiritsUnchained instance = SpiritsUnchained.getInstance();
         final FileConfiguration config = instance.getConfig();
@@ -45,7 +45,7 @@ public class PlayerReleaseSpiritListener implements Listener {
         }
     }
     
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityRemove(EntityRemoveFromWorldEvent event) {
         final Entity entity = event.getEntity();
         final UUID uuid = entity.getUniqueId();

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -27,7 +27,7 @@ public class PlayerReleaseSpiritListener implements Listener {
         final Player player = killedEntity.getKiller();
         final boolean spawnerSpirits = config.getBoolean("options.spawner-spirits", false);
 
-        if (player == null || player.getGameMode() != GameMode.SURVIVAL) {
+        if (player == null || (player.getGameMode() != GameMode.SURVIVAL && config.getBoolean("options.require-survival", true))) {
             return;
         }
 

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -51,6 +51,6 @@ public class PlayerReleaseSpiritListener implements Listener {
     public void onEntityRemove(EntityRemoveFromWorldEvent event) {
         final Entity entity = event.getEntity();
         final UUID uuid = entity.getUniqueId();
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.remove(uuid);
+        SpiritsUnchained.getSpiritEntityManager().entitySet.remove(uuid);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -1,11 +1,13 @@
 package me.justahuman.spiritsunchained.listeners;
 
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.implementation.mobs.AbstractCustomMob;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.GameMode;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -13,7 +15,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
-import org.bukkit.inventory.ItemStack;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -31,12 +32,6 @@ public class PlayerReleaseSpiritListener implements Listener {
             return;
         }
 
-        final ItemStack helmetItem = player.getInventory().getHelmet();
-
-        if (helmetItem == null) {
-            return;
-        }
-
         final EntityType type = killedEntity.getType();
         final AbstractCustomMob<?> spirit = SpiritsUnchained.getSpiritEntityManager().getCustomClass(null, type + "_SPIRIT");
 
@@ -46,8 +41,15 @@ public class PlayerReleaseSpiritListener implements Listener {
 
         final SpiritDefinition definition = SpiritsUnchained.getSpiritsManager().getSpiritMap().get(type);
         final int chance = ThreadLocalRandom.current().nextInt(1, 100);
-        if (SpiritUtils.imbuedCheck(helmetItem) && chance <= 10/definition.getTier() && SpiritUtils.getNearbySpirits(killedEntity.getLocation()).size() < SpiritUtils.getPlayerCap() && (spawnerSpirits || ! killedEntity.fromMobSpawner()) && ! config.getStringList("options.disabled-worlds").contains(killedEntity.getWorld().getName())) {
+        if (PlayerArmorListener.getCanSeeUUIDList().contains(player.getUniqueId()) && chance <= 10/definition.getTier() && SpiritUtils.getNearbySpirits(killedEntity.getLocation()).size() < SpiritUtils.getPlayerCap() && (spawnerSpirits || ! killedEntity.fromMobSpawner()) && ! config.getStringList("options.disabled-worlds").contains(killedEntity.getWorld().getName())) {
             spirit.spawn(killedEntity.getLocation(), killedEntity.getWorld(), "Hostile", null);
         }
+    }
+    
+    @EventHandler
+    public void onEntityRemove(EntityRemoveFromWorldEvent event) {
+        final Entity entity = event.getEntity();
+        final Integer id = entity.getEntityId();
+        SpiritUtils.spiritIdMap.remove(id);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -16,6 +16,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class PlayerReleaseSpiritListener implements Listener {
@@ -49,7 +50,7 @@ public class PlayerReleaseSpiritListener implements Listener {
     @EventHandler
     public void onEntityRemove(EntityRemoveFromWorldEvent event) {
         final Entity entity = event.getEntity();
-        final Integer id = entity.getEntityId();
-        SpiritUtils.spiritIdMap.remove(id);
+        final UUID uuid = entity.getUniqueId();
+        SpiritsUnchained.getSpiritEntityManager().entityCollection.remove(uuid);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/PlayerReleaseSpiritListener.java
@@ -17,7 +17,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class PlayerReleaseSpiritListener implements Listener {
 
@@ -41,8 +40,7 @@ public class PlayerReleaseSpiritListener implements Listener {
         }
 
         final SpiritDefinition definition = SpiritsUnchained.getSpiritsManager().getSpiritMap().get(type);
-        final int chance = ThreadLocalRandom.current().nextInt(1, 100);
-        if (PlayerArmorListener.getCanSeeUUIDList().contains(player.getUniqueId()) && chance <= 10/definition.getTier() && SpiritUtils.getNearbySpirits(killedEntity.getLocation(), 64).size() < SpiritUtils.getPlayerCap() && (spawnerSpirits || ! killedEntity.fromMobSpawner()) && ! config.getStringList("options.disabled-worlds").contains(killedEntity.getWorld().getName())) {
+        if (PlayerArmorListener.getCanSeeUUIDList().contains(player.getUniqueId()) && SpiritUtils.chance(10/definition.getTier()) && SpiritUtils.getNearbySpirits(killedEntity.getLocation(), 64).size() < SpiritUtils.getPlayerCap() && (spawnerSpirits || ! killedEntity.fromMobSpawner()) && ! config.getStringList("options.disabled-worlds").contains(killedEntity.getWorld().getName())) {
             spirit.spawn(killedEntity.getLocation(), killedEntity.getWorld(), "Hostile", null);
         }
     }

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/SpiritItemListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/SpiritItemListeners.java
@@ -2,7 +2,6 @@ package me.justahuman.spiritsunchained.listeners;
 
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/SpiritItemListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/SpiritItemListeners.java
@@ -5,6 +5,7 @@ import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
@@ -12,7 +13,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class SpiritItemListeners implements Listener {
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onTryCraft(CraftItemEvent e) {
         for (ItemStack item : e.getInventory().getMatrix()) {
             if (item != null && item.getType() != Material.AIR && SpiritUtils.isSpiritItem(item)) {
@@ -25,7 +26,7 @@ public class SpiritItemListeners implements Listener {
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPrepareCraft(PrepareItemCraftEvent e) {
         if (e.getInventory().getResult() != null) {
             for (ItemStack item : e.getInventory().getContents()) {

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
@@ -51,8 +51,6 @@ import org.bukkit.util.Vector;
 import org.spigotmc.event.entity.EntityDismountEvent;
 import org.spigotmc.event.entity.EntityMountEvent;
 
-import java.util.Random;
-
 public class TraitListeners implements Listener {
     SpiritsUnchained instance = SpiritsUnchained.getInstance();
 
@@ -177,7 +175,7 @@ public class TraitListeners implements Listener {
         }
         //Natural Thorns
         if (attacker != null && event.getCause() == EntityDamageEvent.DamageCause.ENTITY_ATTACK && SpiritUtils.chance(50) && isUsed(player, EntityType.GUARDIAN)) {
-            final EntityDamageByEntityEvent newEvent = new EntityDamageByEntityEvent(entity, attacker, EntityDamageEvent.DamageCause.THORNS, new Random().nextInt(1,5));
+            final EntityDamageByEntityEvent newEvent = new EntityDamageByEntityEvent(entity, attacker, EntityDamageEvent.DamageCause.THORNS, SpiritUtils.random(1,5));
             newEvent.callEvent();
         }
         //Blazing Thorns

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
@@ -1,6 +1,5 @@
 package me.justahuman.spiritsunchained.listeners;
 
-import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 
 import io.papermc.paper.event.entity.ElderGuardianAppearanceEvent;
@@ -39,7 +38,6 @@ import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.entity.PigZombieAngerEvent;
-import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
@@ -139,7 +137,7 @@ public class TraitListeners implements Listener {
 
         final Entity attacker = event instanceof EntityDamageByEntityEvent otherEvent ? otherEvent.getDamager() : null;
         final double finalHealth = entity.getHealth() - event.getFinalDamage();
-        final double finalHealthPercentage = finalHealth / entity.getMaxHealth();
+        final double finalHealthPercentage = finalHealth / (entity.getAttribute(Attribute.GENERIC_MAX_HEALTH) != null ? entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue() : 1);
 
         //Explosion Traits
         if (attacker != null && PersistentDataAPI.hasString(attacker, Keys.immuneKey) && PersistentDataAPI.getString(attacker, Keys.immuneKey).equals(entity.getUniqueId().toString())) {

--- a/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
+++ b/src/main/java/me/justahuman/spiritsunchained/listeners/TraitListeners.java
@@ -54,7 +54,7 @@ import org.spigotmc.event.entity.EntityMountEvent;
 public class TraitListeners implements Listener {
     SpiritsUnchained instance = SpiritsUnchained.getInstance();
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onProjectileHit(ProjectileHitEvent event) {
         final Projectile projectile = event.getEntity();
         final String key = PersistentDataAPI.hasString(projectile, Keys.entityKey) ? PersistentDataAPI.getString(projectile, Keys.entityKey) : "";
@@ -67,7 +67,7 @@ public class TraitListeners implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onTntExplode(EntityExplodeEvent event) {
         final Entity exploding = event.getEntity();
         if (!PersistentDataAPI.hasString(exploding, Keys.entityKey)) {
@@ -79,7 +79,7 @@ public class TraitListeners implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerShoot(EntityShootBowEvent event) {
         if (!(event.getEntity() instanceof Player player && event.getProjectile() instanceof Arrow arrow1)) {
             return;
@@ -106,7 +106,7 @@ public class TraitListeners implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onEntityDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof LivingEntity entity)) {
             return;
@@ -215,7 +215,7 @@ public class TraitListeners implements Listener {
         }
     }
     //Morning Gift
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerSleep(PlayerDeepSleepEvent event) {
         final Player player = event.getPlayer();
         if (!onCooldown(player, Keys.morningGift) && isUsed(player, EntityType.CAT)) {
@@ -224,7 +224,7 @@ public class TraitListeners implements Listener {
         }
     }
     //Group Protection
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onAngerPigman(PigZombieAngerEvent event) {
         final Entity entity = event.getTarget();
         if (entity instanceof Player player && isUsed(player, EntityType.ZOMBIFIED_PIGLIN)) {
@@ -232,14 +232,14 @@ public class TraitListeners implements Listener {
         }
     }
     //No Fatigue
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerGetFatigue(ElderGuardianAppearanceEvent event) {
         if (isUsed(event.getAffectedPlayer(), EntityType.ELDER_GUARDIAN)) {
             event.setCancelled(true);
         }
     }
     //Undead Protection
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onConsumeItem(PlayerItemConsumeEvent event) {
         final Player player = event.getPlayer();
         final ItemStack item = event.getItem();
@@ -268,7 +268,7 @@ public class TraitListeners implements Listener {
         event.setItem(item);
     }
     //Better Foods
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onHungerChange(FoodLevelChangeEvent event) {
         final HumanEntity entity = event.getEntity();
         if (!(entity instanceof Player player)) {
@@ -280,7 +280,7 @@ public class TraitListeners implements Listener {
         }
     }
     //Better Shears
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerShear(PlayerShearEntityEvent event) {
         final Entity entity = event.getEntity();
         final Player player = event.getPlayer();
@@ -291,7 +291,7 @@ public class TraitListeners implements Listener {
         }
     }
     //Pig Rancher
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerEnter(EntityMountEvent event) {
         final Entity rider = event.getEntity();
         final Entity mount = event.getMount();
@@ -308,7 +308,7 @@ public class TraitListeners implements Listener {
         }
     }
     //Pig Rancher
-    @EventHandler(priority = EventPriority.LOWEST)
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onPlayerLeave(EntityDismountEvent event) {
         final Entity rider = event.getEntity();
         final Entity dismount = event.getDismounted();

--- a/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
@@ -53,22 +53,22 @@ public class CommandManager implements TabExecutor {
         if (! (sender instanceof Player player ) || args.length == 0) {
             return false;
         }
-        if (useCommand("TestParticles", player, 0, 2, args)) {
+        if (useCommand("TestParticles", player, 2, args)) {
             return testParticles(player, args[1]);
         }
-        else if (useCommand("SummonSpirit", player, 0, 2, args)) {
+        else if (useCommand("SummonSpirit", player, 2, args)) {
             return summonSpirit(args[1], player, args.length >= 3 ? args[2] : "COW");
         }
-        else if (useCommand("GiveSpirit", player, 0, 2, args)) {
+        else if (useCommand("GiveSpirit", player, 2, args)) {
             return giveSpirit(player, args[1], args.length >= 3 ? args[2] : "Friendly");
         }
-        else if (useCommand("EditItem", player, 0, 2, args)) {
+        else if (useCommand("EditItem", player, 2, args)) {
             return editItem(player, args[1], args.length >= 3 ? args[2] : "Blank");
         }
-        else if (useCommand("ResetCooldowns", player, 0, 1, args)) {
+        else if (useCommand("ResetCooldowns", player, 1, args)) {
             return resetCooldown(player, args.length >= 2 ? args[1] : player.getName());
         }
-        else if (useCommand("Altar", player, 0, 2, args)) {
+        else if (useCommand("Altar", player, 2, args)) {
             return visualizeAltar(player, args[1]);
         }
         else {
@@ -161,8 +161,8 @@ public class CommandManager implements TabExecutor {
         return Collections.emptyList();
     }
 
-    private boolean useCommand(String command, Player player, int index, int size, String[] args) {
-        return args[index].equalsIgnoreCase(command) && args.length >= size && hasPerm(player, command);
+    private boolean useCommand(String command, Player player, int size, String[] args) {
+        return args[0].equalsIgnoreCase(command) && args.length >= size && hasPerm(player, command);
     }
 
     private boolean hasPerm(Player player, String command) {

--- a/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
@@ -33,6 +33,7 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +45,7 @@ public class CommandManager implements TabExecutor {
 
     final Set<String> spiritTypes = SpiritsUnchained.getSpiritEntityManager().entityMap.keySet();
     final List<String> entityTypes = SpiritUtils.getTypes();
+    public final Collection<FallingBlock> ghostBlocks = new ArrayList<>();
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
@@ -220,6 +222,7 @@ public class CommandManager implements TabExecutor {
                     directional.setFacing(face);
                 }
                 final FallingBlock fallingBlock = world.spawnFallingBlock(relativeLocation, blockData);
+                ghostBlocks.add(fallingBlock);
                 fallingBlock.setVelocity(new Vector(0, 0, 0));
                 fallingBlock.setGravity(false);
                 fallingBlock.setDropItem(false);
@@ -228,6 +231,7 @@ public class CommandManager implements TabExecutor {
                 PersistentDataAPI.setString(fallingBlock, Keys.entityKey, "altar");
                 Bukkit.getScheduler().runTaskLater(SpiritsUnchained.getInstance(), () -> {
                     if (fallingBlock != null) {
+                        ghostBlocks.remove(fallingBlock);
                         fallingBlock.remove();
                     }
                 }, (30 * 20) - (finalEntryIndex * 5L));

--- a/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
@@ -40,12 +40,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 public class CommandManager implements TabExecutor {
 
-    final Set<String> spiritTypes = SpiritsUnchained.getSpiritEntityManager().entityMap.keySet();
-    final List<String> entityTypes = SpiritUtils.getTypes();
-    public final Collection<FallingBlock> ghostBlocks = new ArrayList<>();
+    public final Set<String> spiritTypes = SpiritsUnchained.getSpiritEntityManager().entityMap.keySet();
+    public final List<String> entityTypes = SpiritUtils.getTypes();
+    public final Collection<UUID> ghostBlocks = new ArrayList<>();
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {
@@ -222,7 +223,7 @@ public class CommandManager implements TabExecutor {
                     directional.setFacing(face);
                 }
                 final FallingBlock fallingBlock = world.spawnFallingBlock(relativeLocation, blockData);
-                ghostBlocks.add(fallingBlock);
+                ghostBlocks.add(fallingBlock.getUniqueId());
                 fallingBlock.setVelocity(new Vector(0, 0, 0));
                 fallingBlock.setGravity(false);
                 fallingBlock.setDropItem(false);
@@ -231,7 +232,7 @@ public class CommandManager implements TabExecutor {
                 PersistentDataAPI.setString(fallingBlock, Keys.entityKey, "altar");
                 Bukkit.getScheduler().runTaskLater(SpiritsUnchained.getInstance(), () -> {
                     if (fallingBlock != null) {
-                        ghostBlocks.remove(fallingBlock);
+                        ghostBlocks.remove(fallingBlock.getUniqueId());
                         fallingBlock.remove();
                     }
                 }, (30 * 20) - (finalEntryIndex * 5L));

--- a/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/CommandManager.java
@@ -33,7 +33,6 @@ import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -46,7 +45,7 @@ public class CommandManager implements TabExecutor {
 
     public final Set<String> spiritTypes = SpiritsUnchained.getSpiritEntityManager().entityMap.keySet();
     public final List<String> entityTypes = SpiritUtils.getTypes();
-    public final Collection<UUID> ghostBlocks = new ArrayList<>();
+    public final Set<UUID> ghostBlocks = new HashSet<>();
 
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, String[] args) {

--- a/src/main/java/me/justahuman/spiritsunchained/managers/ConfigManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/ConfigManager.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 @Getter
 public class ConfigManager {
@@ -38,7 +39,7 @@ public class ConfigManager {
     public ConfigManager() {
         // Add missing config entries
         final SpiritsUnchained instance = SpiritsUnchained.getInstance();
-        YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(instance.getResource("config.yml")));
+        YamlConfiguration config = YamlConfiguration.loadConfiguration(new InputStreamReader(Objects.requireNonNull(instance.getResource("config.yml"))));
         for (Map.Entry<String, Object> entry : config.getValues(true).entrySet()) {
             instance.getConfig().addDefault(entry.getKey(), entry.getValue());
         }
@@ -90,6 +91,11 @@ public class ConfigManager {
     @ParametersAreNonnullByDefault
     private void overrideConfiguration(FileConfiguration config, File file, String fileName) throws IOException {
         final InputStream inputStream = SpiritsUnchained.getInstance().getResource(fileName);
+        
+        if (inputStream == null) {
+            return;
+        }
+        
         final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
         final YamlConfiguration defaults = YamlConfiguration.loadConfiguration(reader);
         config.addDefaults(defaults);

--- a/src/main/java/me/justahuman/spiritsunchained/managers/ListenerManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/ListenerManager.java
@@ -3,6 +3,8 @@ package me.justahuman.spiritsunchained.managers;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 import me.justahuman.spiritsunchained.listeners.IdentifyingGlassListener;
 import me.justahuman.spiritsunchained.listeners.PassOnListeners;
+import me.justahuman.spiritsunchained.listeners.PlayerArmorListener;
+import me.justahuman.spiritsunchained.listeners.PlayerJoinListener;
 import me.justahuman.spiritsunchained.listeners.PlayerReleaseSpiritListener;
 import me.justahuman.spiritsunchained.listeners.PlayerClickListener;
 import me.justahuman.spiritsunchained.listeners.SpiritItemListeners;
@@ -16,10 +18,12 @@ public class ListenerManager {
         final PluginManager manager = instance.getServer().getPluginManager();
 
         manager.registerEvents(new IdentifyingGlassListener(), instance);
+        manager.registerEvents(new PassOnListeners(), instance);
+        manager.registerEvents(new PlayerArmorListener(), instance);
         manager.registerEvents(new PlayerClickListener(), instance);
+        manager.registerEvents(new PlayerJoinListener(), instance);
         manager.registerEvents(new PlayerReleaseSpiritListener(), instance);
         manager.registerEvents(new SpiritItemListeners(), instance);
         manager.registerEvents(new TraitListeners(), instance);
-        manager.registerEvents(new PassOnListeners(), instance);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -89,7 +89,7 @@ public class SpiritEntityManager implements Listener {
             }
             
             final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation(), 64).size();
-            if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(25)) {
+            if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(10)) {
                 final Block b = SpiritUtils.getSpawnBlock(player.getLocation());
                 final String maybeSpirit = SpiritUtils.getSpawnMob(b.getLocation());
                 if (maybeSpirit != null && this.entityMap.get("UNIDENTIFIED_SPIRIT") != null) {

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 public class SpiritEntityManager implements Listener {
 
     public final Map<String, AbstractCustomMob<?>> entityMap = new HashMap<>();
-    public final Collection<LivingEntity> entityCollection = new ArrayList<>();
+    public final Collection<UUID> entityCollection = new ArrayList<>();
 
     public SpiritEntityManager() {
         final SpiritsUnchained instance = SpiritsUnchained.getInstance();
@@ -60,12 +60,23 @@ public class SpiritEntityManager implements Listener {
         String getKey = entity != null && PersistentDataAPI.hasString(entity, Keys.entityKey) ? PersistentDataAPI.getString(entity, Keys.entityKey) : key;
         return getKey == null ? null : this.entityMap.get(getKey);
     }
+    
+    public Collection<LivingEntity> getCustomLivingEntities() {
+        final Collection<LivingEntity> toReturn = new ArrayList<>();
+        for (UUID uuid : entityCollection) {
+            final Entity entity = Bukkit.getEntity(uuid);
+            if (entity instanceof LivingEntity livingEntity) {
+                toReturn.add(livingEntity);
+            }
+        }
+        return toReturn;
+    }
 
     private void tick() {
-        for (LivingEntity entity : entityCollection) {
-            final AbstractCustomMob<?> customMob = getCustomClass(entity, null);
+        for (LivingEntity livingEntity : getCustomLivingEntities()) {
+            final AbstractCustomMob<?> customMob = getCustomClass(livingEntity, null);
             if (customMob != null) {
-                customMob.onEntityTick(entity);
+                customMob.onEntityTick(livingEntity);
             }
         }
     }
@@ -77,7 +88,7 @@ public class SpiritEntityManager implements Listener {
                 continue;
             }
             
-            final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation()).size();
+            final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation(), 64).size();
             if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(25)) {
                 final Block b = SpiritUtils.getSpawnBlock(player.getLocation());
                 final String maybeSpirit = SpiritUtils.getSpawnMob(b.getLocation());

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -10,7 +10,6 @@ import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Entity;
@@ -25,7 +24,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
@@ -63,34 +61,27 @@ public class SpiritEntityManager implements Listener {
     }
 
     private void tick() {
-        for (World world : Bukkit.getWorlds()) {
-            for (LivingEntity entity : world.getLivingEntities()) {
-                final AbstractCustomMob<?> customMob = getCustomClass(entity, null);
-                if (customMob != null) {
-                    customMob.onEntityTick(entity);
-                }
+        for (LivingEntity entity : entityCollection) {
+            final AbstractCustomMob<?> customMob = getCustomClass(entity, null);
+            if (customMob != null) {
+                customMob.onEntityTick(entity);
             }
         }
     }
 
     private void spawnTick() {
-        for (World world : Bukkit.getWorlds()) {
-            if (SpiritsUnchained.getInstance().getConfig().getStringList("options.disabled-worlds").contains(world.getName())) {
+        for (UUID uuid : PlayerArmorListener.getCanSeeUUIDList()) {
+            final Player player = Bukkit.getPlayer(uuid);
+            if (player == null || player.getGameMode() != GameMode.SURVIVAL || SpiritsUnchained.getInstance().getConfig().getStringList("options.disabled-worlds").contains(player.getWorld().getName())) {
                 continue;
             }
-            for (UUID uuid : PlayerArmorListener.getCanSeeUUIDList()) {
-                final Player player = Bukkit.getPlayer(uuid);
-                if (player == null || player.getGameMode() != GameMode.SURVIVAL) {
-                    continue;
-                }
-                final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation()).size();
-                
-                if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(10)) {
-                    final Block b = SpiritUtils.getSpawnBlock(player.getLocation());
-                    final String maybeSpirit = SpiritUtils.getSpawnMob(b.getLocation());
-                    if (maybeSpirit != null && this.entityMap.get("UNIDENTIFIED_SPIRIT") != null) {
-                        this.entityMap.get("UNIDENTIFIED_SPIRIT").spawn(b.getLocation(), player.getWorld(), "Natural", maybeSpirit);
-                    }
+            
+            final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation()).size();
+            if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(10)) {
+                final Block b = SpiritUtils.getSpawnBlock(player.getLocation());
+                final String maybeSpirit = SpiritUtils.getSpawnMob(b.getLocation());
+                if (maybeSpirit != null && this.entityMap.get("UNIDENTIFIED_SPIRIT") != null) {
+                    this.entityMap.get("UNIDENTIFIED_SPIRIT").spawn(b.getLocation(), player.getWorld(), "Natural", maybeSpirit);
                 }
             }
         }

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -77,7 +77,7 @@ public class SpiritEntityManager implements Listener {
             }
             
             final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation()).size();
-            if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(10)) {
+            if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(25)) {
                 final Block b = SpiritUtils.getSpawnBlock(player.getLocation());
                 final String maybeSpirit = SpiritUtils.getSpawnMob(b.getLocation());
                 if (maybeSpirit != null && this.entityMap.get("UNIDENTIFIED_SPIRIT") != null) {

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -27,16 +27,16 @@ import org.bukkit.event.entity.EntityTargetEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public class SpiritEntityManager implements Listener {
 
     public final Map<String, AbstractCustomMob<?>> entityMap = new HashMap<>();
-    public final Collection<UUID> entityCollection = new ArrayList<>();
+    public final Set<UUID> entitySet = new HashSet<>();
 
     public SpiritEntityManager() {
         final SpiritsUnchained instance = SpiritsUnchained.getInstance();
@@ -61,9 +61,9 @@ public class SpiritEntityManager implements Listener {
         return getKey == null ? null : this.entityMap.get(getKey);
     }
     
-    public Collection<LivingEntity> getCustomLivingEntities() {
-        final Collection<LivingEntity> toReturn = new ArrayList<>();
-        for (UUID uuid : entityCollection) {
+    public Set<LivingEntity> getCustomLivingEntities() {
+        final Set<LivingEntity> toReturn = new HashSet<>();
+        for (UUID uuid : entitySet) {
             final Entity entity = Bukkit.getEntity(uuid);
             if (entity instanceof LivingEntity livingEntity) {
                 toReturn.add(livingEntity);
@@ -151,6 +151,6 @@ public class SpiritEntityManager implements Listener {
     private void onEntityRemove(@Nonnull EntityRemoveFromWorldEvent event) {
         final Entity entity = event.getEntity();
         final UUID uuid = entity.getUniqueId();
-        SpiritsUnchained.getSpiritEntityManager().entityCollection.remove(uuid);
+        SpiritsUnchained.getSpiritEntityManager().entitySet.remove(uuid);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -100,58 +100,57 @@ public class SpiritEntityManager implements Listener {
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    private void onEntityTarget(@Nonnull EntityTargetEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getEntity(), null);
+    private void onEntityTarget(@Nonnull EntityTargetEvent event) {
+        final AbstractCustomMob<?> customMob = getCustomClass(event.getEntity(), null);
         if (customMob != null) {
-            customMob.onTarget(e);
+            customMob.onTarget(event);
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.LOWEST)
-    private void onEntityInteract(@Nonnull PlayerInteractEntityEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getRightClicked(), null);
+    private void onEntityInteract(@Nonnull PlayerInteractEntityEvent event) {
+        final AbstractCustomMob<?> customMob = getCustomClass(event.getRightClicked(), null);
         if (customMob != null) {
-            customMob.onInteract(e);
+            customMob.onInteract(event);
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    private void onEntityHit(@Nonnull EntityDamageByEntityEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getEntity(), null);
+    private void onEntityHit(@Nonnull EntityDamageByEntityEvent event) {
+        final AbstractCustomMob<?> customMob = getCustomClass(event.getEntity(), null);
         if (customMob != null) {
-            customMob.onHit(e);
+            customMob.onHit(event);
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    private void onEntityDie(@Nonnull EntityDeathEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getEntity(), null);
+    private void onEntityDie(@Nonnull EntityDeathEvent event) {
+        final AbstractCustomMob<?> customMob = getCustomClass(event.getEntity(), null);
         if (customMob != null) {
-            customMob.onDeath(e);
+            customMob.onDeath(event);
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    private void onEntityCombust(@Nonnull EntityCombustEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getEntity(), null);
+    private void onEntityCombust(@Nonnull EntityCombustEvent event) {
+        final AbstractCustomMob<?> customMob = getCustomClass(event.getEntity(), null);
         if (customMob != null) {
-            e.setCancelled(true);
+            event.setCancelled(true);
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    private void onEntityDamage(@Nonnull EntityDamageEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getEntity(), null);
+    private void onEntityDamage(@Nonnull EntityDamageEvent event) {
+        final AbstractCustomMob<?> customMob = getCustomClass(event.getEntity(), null);
         if (customMob != null) {
-            customMob.onDamage(e);
+            customMob.onDamage(event);
         }
     }
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-    private void onEntityRemove(@Nonnull EntityRemoveFromWorldEvent e) {
-        final AbstractCustomMob<?> customMob = getCustomClass(e.getEntity(), null);
-        if (customMob != null) {
-            this.entityCollection.remove((LivingEntity) e.getEntity());
-        }
+    private void onEntityRemove(@Nonnull EntityRemoveFromWorldEvent event) {
+        final Entity entity = event.getEntity();
+        final UUID uuid = entity.getUniqueId();
+        SpiritsUnchained.getSpiritEntityManager().entityCollection.remove(uuid);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritEntityManager.java
@@ -5,6 +5,7 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.Persis
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 
 import me.justahuman.spiritsunchained.implementation.mobs.AbstractCustomMob;
+import me.justahuman.spiritsunchained.listeners.PlayerArmorListener;
 import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Bukkit;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 public class SpiritEntityManager implements Listener {
 
@@ -76,15 +78,13 @@ public class SpiritEntityManager implements Listener {
             if (SpiritsUnchained.getInstance().getConfig().getStringList("options.disabled-worlds").contains(world.getName())) {
                 continue;
             }
-            for (Player player : world.getPlayers()) {
-                if (player.getGameMode() != GameMode.SURVIVAL) {
+            for (UUID uuid : PlayerArmorListener.getCanSeeUUIDList()) {
+                final Player player = Bukkit.getPlayer(uuid);
+                if (player == null || player.getGameMode() != GameMode.SURVIVAL) {
                     continue;
                 }
                 final int spiritCount = SpiritUtils.getNearbySpirits(player.getLocation()).size();
-                final ItemStack helmetItem = player.getInventory().getHelmet();
-                if (helmetItem == null || !SpiritUtils.imbuedCheck(helmetItem)) {
-                    continue;
-                }
+                
                 if (SpiritUtils.canSpawn() && spiritCount < SpiritUtils.getPlayerCap() && SpiritUtils.chance(10)) {
                     final Block b = SpiritUtils.getSpawnBlock(player.getLocation());
                     final String maybeSpirit = SpiritUtils.getSpawnMob(b.getLocation());

--- a/src/main/java/me/justahuman/spiritsunchained/managers/SpiritsManager.java
+++ b/src/main/java/me/justahuman/spiritsunchained/managers/SpiritsManager.java
@@ -1,7 +1,6 @@
 package me.justahuman.spiritsunchained.managers;
 
 import me.justahuman.spiritsunchained.SpiritsUnchained;
-import me.justahuman.spiritsunchained.listeners.PassOnListeners;
 import me.justahuman.spiritsunchained.utils.LogUtils;
 import me.justahuman.spiritsunchained.spirits.Goal;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
@@ -13,6 +12,7 @@ import org.bukkit.entity.EntityType;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,11 +20,11 @@ import java.util.Map;
 public class SpiritsManager {
 
     @Getter
-    private final Map<EntityType, SpiritDefinition> spiritMap = new HashMap<>();
+    private final Map<EntityType, SpiritDefinition> spiritMap = new EnumMap<>(EntityType.class);
     @Getter
     private final List<List<EntityType>> tierMaps = new ArrayList<>();
     @Getter
-    private final Map<EntityType, List<EntityType>> goalRequirements = new HashMap<>();
+    private final Map<EntityType, List<EntityType>> goalRequirements = new EnumMap<>(EntityType.class);
 
     public SpiritsManager() {
         tierMaps.add(new ArrayList<>());
@@ -83,13 +83,15 @@ public class SpiritsManager {
             relations.put("Afraid", afraid);
 
             if (listGoal.get(0).equals("Kill") || listGoal.get(0).equals("Breed")) {
-                EntityType requirementType = null;
+                EntityType requirementType;
                 try {
                     requirementType = EntityType.valueOf(listGoal.get(1));
                     final List<EntityType> requiredFor = goalRequirements.containsKey(requirementType) ? goalRequirements.get(requirementType) : new ArrayList<>();
                     requiredFor.add(type);
                     goalRequirements.put(requirementType, requiredFor);
-                } catch(IllegalArgumentException | NullPointerException ignored) {}
+                } catch(IllegalArgumentException | NullPointerException ignored) {
+                    // Someone Messed Something Up
+                }
             }
 
             final SpiritDefinition spiritDefinition = new SpiritDefinition(

--- a/src/main/java/me/justahuman/spiritsunchained/runnables/PassivesRunnable.java
+++ b/src/main/java/me/justahuman/spiritsunchained/runnables/PassivesRunnable.java
@@ -1,6 +1,6 @@
 package me.justahuman.spiritsunchained.runnables;
 
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import me.justahuman.spiritsunchained.utils.PlayerUtils;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Bukkit;
@@ -50,7 +50,7 @@ public class PassivesRunnable extends BukkitRunnable {
             for (ItemStack item : inventory.getContents()) {
                 if (item != null && item.getType() == Material.GOLD_INGOT) {
                     item.subtract();
-                    PlayerUtils.addOrDropItem(player, SlimefunItem.getById("STRANGE_NETHER_GOO").getItem().clone());
+                    PlayerUtils.addOrDropItem(player, SlimefunItems.STRANGE_NETHER_GOO.clone());
                 }
             }
         }

--- a/src/main/java/me/justahuman/spiritsunchained/runnables/RelationsAndStateRunnable.java
+++ b/src/main/java/me/justahuman/spiritsunchained/runnables/RelationsAndStateRunnable.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -66,7 +65,7 @@ public class RelationsAndStateRunnable extends BukkitRunnable {
             for (EntityType scareType : relations.get("Scare")) {
                 final Set<ItemStack> scared = cacheEntry.containsKey(scareType) ? cacheEntry.get(scareType) : new HashSet<>();
                 for (ItemStack scare : scared) {
-                    SpiritUtils.updateSpiritItemProgress(scare, (double) - 1 / new Random().nextInt(1, 5));
+                    SpiritUtils.updateSpiritItemProgress(scare, (double) - 1 / SpiritUtils.random(1, 5));
                     world.dropItemNaturally(location, scare.clone());
                     inventory.remove(scare);
                     world.playSound(location, Sound.ENTITY_ITEM_PICKUP, 2, 1);
@@ -75,16 +74,16 @@ public class RelationsAndStateRunnable extends BukkitRunnable {
             }
 
             if (SpiritsUnchained.getInstance().getConfig().getBoolean("options.hostile-movement", true) && state.equals("Hostile")) {
-                final int index = new Random().nextInt(contents.length);
+                final int index = SpiritUtils.random(0, contents.length);
                 final ItemStack toMove = inventory.getItem(index) != null ? inventory.getItem(index).clone() : null;
-                final int moveTo = new Random().nextInt(contents.length);
+                final int moveTo = SpiritUtils.random(0, contents.length);
                 final ItemStack toSwitch = inventory.getItem(moveTo) != null ? inventory.getItem(moveTo).clone() : null;
                 inventory.setItem(index, toSwitch);
                 inventory.setItem(moveTo, toMove);
             }
 
             if (SpiritsUnchained.getInstance().getConfig().getBoolean("options.aggressive-damage", true) && (state.equals("Hostile") || state.equals("Aggressive"))) {
-                player.damage(new Random().nextInt(2));
+                player.damage(SpiritUtils.random(0, 2));
             }
         }
         spiritCache.put(player.getUniqueId(), cacheEntry);

--- a/src/main/java/me/justahuman/spiritsunchained/runnables/RelationsAndStateRunnable.java
+++ b/src/main/java/me/justahuman/spiritsunchained/runnables/RelationsAndStateRunnable.java
@@ -1,10 +1,8 @@
 package me.justahuman.spiritsunchained.runnables;
 
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import lombok.Getter;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
-import me.justahuman.spiritsunchained.implementation.tools.PortableAltar;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
@@ -12,7 +10,6 @@ import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.World;

--- a/src/main/java/me/justahuman/spiritsunchained/runnables/RelationsAndStateRunnable.java
+++ b/src/main/java/me/justahuman/spiritsunchained/runnables/RelationsAndStateRunnable.java
@@ -1,8 +1,10 @@
 package me.justahuman.spiritsunchained.runnables;
 
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import lombok.Getter;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
+import me.justahuman.spiritsunchained.implementation.tools.PortableAltar;
 import me.justahuman.spiritsunchained.spirits.SpiritDefinition;
 import me.justahuman.spiritsunchained.utils.Keys;
 import me.justahuman.spiritsunchained.utils.ParticleUtils;
@@ -46,11 +48,10 @@ public class RelationsAndStateRunnable extends BukkitRunnable {
     private void checkSpirits(Player player, Map<EntityType, SpiritDefinition> spiritMap) {
         final EnumMap<EntityType, Set<ItemStack>> cacheEntry = new EnumMap<>(EntityType.class);
         final Inventory inventory = player.getInventory();
-
         final ItemStack[] contents = inventory.getContents();
         for (ItemStack item : contents) {
             //If it's not a Spirit I don't want it
-            if (item == null || item.getType() != Material.FIREWORK_STAR || ! SpiritUtils.isSpiritItem(item)) {
+            if (! SpiritUtils.isSpiritItem(item)) {
                 continue;
             }
 
@@ -68,7 +69,7 @@ public class RelationsAndStateRunnable extends BukkitRunnable {
             for (EntityType scareType : relations.get("Scare")) {
                 final Set<ItemStack> scared = cacheEntry.containsKey(scareType) ? cacheEntry.get(scareType) : new HashSet<>();
                 for (ItemStack scare : scared) {
-                    SpiritUtils.updateSpiritItemProgress(scare, (double) 1 / new Random().nextInt(1, 5));
+                    SpiritUtils.updateSpiritItemProgress(scare, (double) - 1 / new Random().nextInt(1, 5));
                     world.dropItemNaturally(location, scare.clone());
                     inventory.remove(scare);
                     world.playSound(location, Sound.ENTITY_ITEM_PICKUP, 2, 1);

--- a/src/main/java/me/justahuman/spiritsunchained/slimefun/ItemStacks.java
+++ b/src/main/java/me/justahuman/spiritsunchained/slimefun/ItemStacks.java
@@ -1,6 +1,5 @@
 package me.justahuman.spiritsunchained.slimefun;
 
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.attributes.MachineTier;
@@ -8,8 +7,6 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.MachineType;
 import io.github.thebusybiscuit.slimefun4.utils.LoreBuilder;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ColoredFireworkStar;
 
-import me.justahuman.spiritsunchained.SpiritsUnchained;
-import me.justahuman.spiritsunchained.managers.ConfigManager;
 import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -20,8 +17,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-
-import java.util.List;
 
 public class ItemStacks {
 
@@ -37,13 +32,13 @@ public class ItemStacks {
         return itemStack;
     }
 
-    private static ItemStack getPotionColor(Material material, int r, int g, int b) {
-        final ItemStack itemStack = new ItemStack(material);
+    private static ItemStack getPotionColor() {
+        final ItemStack itemStack = new ItemStack(Material.SPLASH_POTION);
         final ItemMeta itemMeta = itemStack.getItemMeta();
         if (itemMeta != null) {
             itemMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
             PotionMeta potionMeta = (PotionMeta) itemMeta;
-            potionMeta.setColor(Color.fromRGB(r, g, b));
+            potionMeta.setColor(Color.fromRGB(150, 150, 150));
             itemStack.setItemMeta(potionMeta);
         }
         return  itemStack;
@@ -72,10 +67,10 @@ public class ItemStacks {
         return lore;
     }
 
-    private static ItemStack addPotionEffect(PotionEffectType type, ItemStack itemStack, int duration, int amplifier) {
+    private static ItemStack addPotionEffect(ItemStack itemStack) {
         final ItemMeta itemMeta = itemStack.getItemMeta();
         final PotionMeta potionMeta = (PotionMeta) itemMeta;
-        potionMeta.addCustomEffect(new PotionEffect(type, duration * 20, amplifier), true);
+        potionMeta.addCustomEffect(new PotionEffect(PotionEffectType.LEVITATION, 5 * 20, 1), true);
         itemStack.setItemMeta(potionMeta);
         return itemStack;
     }
@@ -120,7 +115,7 @@ public class ItemStacks {
 
     public static final SlimefunItemStack SU_SPIRIT_BOTTLE = new SlimefunItemStack(
             "SU_SPIRIT_BOTTLE",
-            addPotionEffect(PotionEffectType.LEVITATION, getPotionColor(Material.SPLASH_POTION, 150,150,150), 5, 1),
+            addPotionEffect(getPotionColor()),
             name("spirit_bottle"),
             lore("spirit_bottle")
     );
@@ -209,7 +204,7 @@ public class ItemStacks {
 
     // Altar Building Blocks
 
-    public static final String[] altarLore = lore("altars");
+    private static final String[] altarLore = lore("altars");
 
     public static final SlimefunItemStack SU_CHARGED_QUARTZ_I = new SlimefunItemStack(
             "SU_CHARGED_QUARTZ_I",

--- a/src/main/java/me/justahuman/spiritsunchained/slimefun/Items.java
+++ b/src/main/java/me/justahuman/spiritsunchained/slimefun/Items.java
@@ -62,10 +62,11 @@ public class Items {
         ItemStack outputEctoplasm = ItemStacks.SU_ECTOPLASM.clone();
         outputEctoplasm.setAmount(2);
         new SlimefunItem(Groups.SU_RESOURCES, ItemStacks.SU_ECTOPLASM, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[]{
+                ItemStacks.SU_SPIRIT_BOTTLE, null, null,
                 null, null, null,
-                null, ItemStacks.SU_SPIRIT_BOTTLE, null,
                 null, null, null
         }, outputEctoplasm).register(instance);
+
 
         //Tools
         new SlimefunItem(Groups.SU_TOOLS, ItemStacks.SU_SPIRIT_LENSES, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{

--- a/src/main/java/me/justahuman/spiritsunchained/slimefun/Items.java
+++ b/src/main/java/me/justahuman/spiritsunchained/slimefun/Items.java
@@ -24,8 +24,8 @@ public class Items {
 
         final RecipeType spiritInteract = new RecipeType(Keys.spiritInteractKey,
                 new ColoredFireworkStar(Color.fromRGB(100, 100, 100),
-                        name("spirit_interact"),
-                        lore("spirit_interact")
+                        name(),
+                        lore()
                 ));
 
         // Crafting Materials
@@ -190,15 +190,15 @@ public class Items {
         new Tier3Altar().register(instance);
     }
 
-    private static String translate(String path) {
-        return SpiritUtils.getTranslation("names.recipe_type." + path);
+    private static String translate() {
+        return SpiritUtils.getTranslation("names.recipe_type." + "spirit_interact.name");
     }
 
-    private static String name(String path) {
-        return translate(path + ".name");
+    private static String name() {
+        return translate();
     }
 
-    private static String[] lore(String path) {
-        return SpiritUtils.getTranslationList("names.recipe_type." + path + ".lore").toArray(String[]::new);
+    private static String[] lore() {
+        return SpiritUtils.getTranslationList("names.recipe_type." + "spirit_interact" + ".lore").toArray(String[]::new);
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/spirits/Goal.java
+++ b/src/main/java/me/justahuman/spiritsunchained/spirits/Goal.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 
-import me.justahuman.spiritsunchained.utils.SpiritUtils;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -24,6 +23,10 @@ public class Goal {
     private final String requiredType;
     private final ItemStack requiredStack;
     private final int amount;
+    private static final ItemStack INVALID_ITEM = new CustomItemStack(
+            Material.BARRIER,
+            "&aInvalid Item! Check Config"
+    );
 
     public Goal(String goalType, String requiredType, int amount) {
         this.goalType = goalType;
@@ -103,7 +106,7 @@ public class Goal {
         if (goalType.equals("Item")) {
             toReturn = new ItemStack(Material.valueOf(requiredType));
         } else if (goalType.equals("SlimefunItem")) {
-            toReturn = SlimefunItem.getById(requiredType).getItem().clone();
+            toReturn = SlimefunItem.getById(requiredType) != null ? SlimefunItem.getById(requiredType).getItem().clone() : INVALID_ITEM;
         }
         return toReturn;
     }

--- a/src/main/java/me/justahuman/spiritsunchained/spirits/SpiritsFlexGroup.java
+++ b/src/main/java/me/justahuman/spiritsunchained/spirits/SpiritsFlexGroup.java
@@ -165,7 +165,7 @@ public class SpiritsFlexGroup extends FlexItemGroup {
     @ParametersAreNonnullByDefault
     private void prepare(Player player, PlayerProfile profile, SlimefunGuideMode mode, ChestMenu menu, int page) {
         final List<SpiritDefinition> spiritList = new ArrayList<>(SpiritsUnchained.getSpiritsManager().getSpiritMap().values());
-        final int spiritCount = SpiritsUnchained.getSpiritsManager().getSpiritMap().size();
+        final int spiritCount = spiritList.size();
         final int totalPages = (int) Math.ceil(spiritCount / (double) PAGE_SIZE);
         final int start = (page - 1) * PAGE_SIZE;
         final int end = Math.min(start + PAGE_SIZE, spiritCount);

--- a/src/main/java/me/justahuman/spiritsunchained/utils/Keys.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/Keys.java
@@ -8,6 +8,7 @@ public class Keys {
 
     private static final SpiritsUnchained instance = SpiritsUnchained.getInstance();
 
+    public static final NamespacedKey despawnKey = new NamespacedKey(instance, "despawn");
     public static final NamespacedKey immuneKey = new NamespacedKey(instance, "immune");
     public static final NamespacedKey imbuedKey = new NamespacedKey(instance, "imbued");
     public static final NamespacedKey spiritIdentified = new NamespacedKey(instance, "identified");

--- a/src/main/java/me/justahuman/spiritsunchained/utils/ParticleUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/ParticleUtils.java
@@ -8,8 +8,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import java.util.Collection;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static me.justahuman.spiritsunchained.utils.SpiritUtils.getNearImbued;
 
@@ -32,9 +30,9 @@ public class ParticleUtils {
 
     public static void spawnParticleRadius(Location location, Particle particle, double radius, int amount, String type, Object... other) {
         for (int i = 0; i < amount; i++) {
-            final double x = ThreadLocalRandom.current().nextDouble(- radius, radius + 0.1);
-            final double y = ThreadLocalRandom.current().nextDouble(- radius, radius + 0.1);
-            final double z = ThreadLocalRandom.current().nextDouble(- radius, radius + 0.1);
+            final double x = SpiritUtils.random(- radius, radius + 0.1);
+            final double y = SpiritUtils.random(- radius, radius + 0.1);
+            final double z = SpiritUtils.random(- radius, radius + 0.1);
             final World world = location.getWorld();
             switch (type) {
                 case "Colored" -> world.spawnParticle(particle, location.clone().add(x, y, z), 1, 0, 0, 0,(Particle.DustOptions) other[0]);
@@ -65,7 +63,7 @@ public class ParticleUtils {
         world.playSound(location, Sound.ENTITY_ENDER_EYE_DEATH, 1, 1);
         double[] speeds = new double[] {0.1, 0.15, 0.2, 0.25,};
         for (double[] offsets : sphere) {
-            world.spawnParticle(Particle.END_ROD, location.clone().add(offsets[0], offsets[1], offsets[2]), 0, 0, 5, 0, speeds[new Random().nextInt(0, speeds.length)]);
+            world.spawnParticle(Particle.END_ROD, location.clone().add(offsets[0], offsets[1], offsets[2]), 0, 0, 5, 0, speeds[SpiritUtils.random(0, speeds.length)]);
         }
     }
 

--- a/src/main/java/me/justahuman/spiritsunchained/utils/ParticleUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/ParticleUtils.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static me.justahuman.spiritsunchained.utils.SpiritUtils.getNearImbued;
 
@@ -38,8 +39,8 @@ public class ParticleUtils {
                 case "Colored" -> world.spawnParticle(particle, location.clone().add(x, y, z), 1, 0, 0, 0,(Particle.DustOptions) other[0]);
                 case "Freeze" -> world.spawnParticle(particle, location.clone().add(x, y, z), 1, 0, 0, 0, 0);
                 case "Spirit" -> {
-                    final Collection<Player> collection = getNearImbued(location);
-                    for (Player player : collection) {
+                    final Set<Player> set = getNearImbued(location);
+                    for (Player player : set) {
                         player.spawnParticle(particle, location.clone().add(x, y, z), 1, 0, 0, 0, 0);
                     }
                 }

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
@@ -1,10 +1,8 @@
 package me.justahuman.spiritsunchained.utils;
 
-import io.github.bakedlibs.dough.protection.modules.GriefPreventionProtectionModule;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
-import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
 
 import org.bukkit.Bukkit;
@@ -31,7 +29,6 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.entity.ShulkerBullet;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.entity.WitherSkull;
-import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
@@ -4,7 +4,6 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -46,9 +45,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 
+@SuppressWarnings("unused")
 public class SpiritTraits {
 
     static final Map<UUID, Map<String, Long>> Cooldown_Map = new HashMap<>();
@@ -142,10 +141,10 @@ public class SpiritTraits {
     public static void Bee_Buddy(Player player) {
         final World world = player.getWorld();
         final Location location = player.getLocation();
-        final ItemStack item = (Math.random() <= 0.5) ? new ItemStack(Material.HONEYCOMB) : new ItemStack(Material.HONEY_BOTTLE);
+        final ItemStack item = (SpiritUtils.random(0.0, 1.0) <= 0.5) ? new ItemStack(Material.HONEYCOMB) : new ItemStack(Material.HONEY_BOTTLE);
         ParticleUtils.spawnParticleRadius(location.add(0, 0.5, 0), Particle.DRIPPING_HONEY, 3, 20, "");
 
-        item.setAmount(new Random().nextInt(1,6));
+        item.setAmount(SpiritUtils.random(1,6));
         world.playSound(location, Sound.BLOCK_BEEHIVE_SHEAR, 2, 1);
         PlayerUtils.addOrDropItem(player, item);
     }
@@ -205,7 +204,7 @@ public class SpiritTraits {
         }
     }
     public static void Stew_Maker(Player player) {
-        fillItems(player, Material.BOWL, new ItemStack(Material.MUSHROOM_STEW), 4);
+        fillItems(player, Material.BOWL, new ItemStack(Material.MUSHROOM_STEW), 5);
     }
     public static void Lava_Walker(Player player) {
         player.addPotionEffect(new PotionEffect(PotionEffectType.FIRE_RESISTANCE, 60*20, 0, true));
@@ -256,7 +255,7 @@ public class SpiritTraits {
                         Material.VERDANT_FROGLIGHT,
                         Material.PEARLESCENT_FROGLIGHT
                 };
-                final Material newMaterial = chooseFrom[new Random().nextInt(3)];
+                final Material newMaterial = chooseFrom[SpiritUtils.random(0,3)];
                 relative.setType(newMaterial);
                 ParticleUtils.spawnParticleRadius(relative.getLocation(), Particle.END_ROD, 1.5, 24, "Freeze");
             }
@@ -284,7 +283,7 @@ public class SpiritTraits {
                 Sound.ITEM_GOAT_HORN_SOUND_6,
                 Sound.ITEM_GOAT_HORN_SOUND_7
         };
-        player.getWorld().playSound(player.getLocation(), playFrom[new Random().nextInt(0,8)], 2, 1);
+        player.getWorld().playSound(player.getLocation(), playFrom[SpiritUtils.random(0,8)], 2, 1);
     }
     public static void Poison_Spray(Player player) {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_LLAMA_SPIT, 2, 1);
@@ -309,9 +308,9 @@ public class SpiritTraits {
         ParticleUtils.spawnParticleRadius(location, Particle.PORTAL, 1.5, 30, "");
 
         for (int i = 0; i < 16; i++) {
-            final int x = location.clone().getBlockX() + new Random().nextInt(1, 33);
-            final int y = location.clone().getBlockY() + new Random().nextInt(1, 33);
-            final int z = location.clone().getBlockZ() + new Random().nextInt(1, 33);
+            final int x = location.clone().getBlockX() + SpiritUtils.random(1, 33);
+            final int y = location.clone().getBlockY() + SpiritUtils.random(1, 33);
+            final int z = location.clone().getBlockZ() + SpiritUtils.random(1, 33);
             final Location teleportTo = new Location(location.getWorld(), x, y ,z);
              if (player.teleport(teleportTo, PlayerTeleportEvent.TeleportCause.CHORUS_FRUIT)) {
                  ParticleUtils.spawnParticleRadius(teleportTo, Particle.PORTAL, 1.5, 30, "");
@@ -355,9 +354,9 @@ public class SpiritTraits {
             final ItemStack[] potions = new ItemStack[] {
                     potion1, potion2, potion3
             };
-            final int amount = new Random().nextInt(5);
+            final int amount = SpiritUtils.random(0, 5);
             for (int current = 0; current < amount; current++) {
-                fillItems(player, Material.GLASS_BOTTLE, potions[new Random().nextInt(3)], 1);
+                fillItems(player, Material.GLASS_BOTTLE, potions[SpiritUtils.random(0, 4)], 1);
             }
         }
     }
@@ -367,7 +366,7 @@ public class SpiritTraits {
     }
     public static void Targeted_Teleport(Player player) {
         final RayTraceResult rs = player.getWorld().rayTraceBlocks(player.getEyeLocation(), player.getEyeLocation().getDirection(), 64);
-        if (rs == null) {
+        if (rs == null || rs.getHitBlock() == null) {
             return;
         }
         final Location location = player.getLocation();
@@ -400,9 +399,9 @@ public class SpiritTraits {
             targets.add(nearbyEntity);
         }
         for (int spawned = 0; spawned < 5; spawned++) {
-            final LivingEntity target = !targets.isEmpty() ? targets.get(new Random().nextInt(targets.size())) : null;
-            final int x = new Random().nextInt(0, 5) * (new Random().nextDouble() >= 0.5 ? -1 : 1);
-            final int z = new Random().nextInt(0, 5) * (new Random().nextDouble() >= 0.5 ? -1 : 1);
+            final LivingEntity target = !targets.isEmpty() ? targets.get(SpiritUtils.random(0, targets.size())) : null;
+            final int x = SpiritUtils.random(0, 5) * (SpiritUtils.random(0.0, 1.0) >= 0.5 ? -1 : 1);
+            final int z = SpiritUtils.random(0, 5) * (SpiritUtils.random(0.0, 1.0) >= 0.5 ? -1 : 1);
             final ShulkerBullet bullet = (ShulkerBullet) world.spawnEntity(location.add(x,2,z), EntityType.SHULKER_BULLET);
             PersistentDataAPI.setString(bullet, Keys.immuneKey, player.getUniqueId().toString());
             bullet.setShooter(player);
@@ -417,7 +416,7 @@ public class SpiritTraits {
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_WITHER_SHOOT, 2, 1);
     }
     public static void Dragons_Breath(Player player) {
-        fillItems(player, Material.GLASS_BOTTLE, new ItemStack(Material.DRAGON_BREATH), 8);
+        fillItems(player, Material.GLASS_BOTTLE, new ItemStack(Material.DRAGON_BREATH), 9);
     }
     public static void Dark_Aura(Player player) {
         final World world = player.getWorld();
@@ -440,7 +439,7 @@ public class SpiritTraits {
             int fillAmount = 0;
             for(ItemStack item : inventory.getContents()) {
                 if (item != null && item.getType() == fill) {
-                    fillAmount = (item.getAmount() >= howMany ? new Random().nextInt(1,howMany + 1) : new Random().nextInt(0,item.getAmount()));
+                    fillAmount = (item.getAmount() >= howMany ? SpiritUtils.random(1, howMany) : SpiritUtils.random(0, item.getAmount()));
                     item.setAmount(item.getAmount() - fillAmount);
                 }
             }

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritTraits.java
@@ -198,7 +198,7 @@ public class SpiritTraits {
         }
     }
     public static void Echolocation(Player player) {
-        player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1*20, 0, true));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 20, 0, true));
         player.getWorld().playSound(player.getLocation(), Sound.ENTITY_BAT_AMBIENT, 1, 1);
         for(LivingEntity entity: player.getWorld().getNearbyLivingEntities(player.getLocation(), 100, 100, 100)) {
             if (entity.getUniqueId() == player.getUniqueId()) {

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
@@ -8,7 +8,6 @@ import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import me.justahuman.spiritsunchained.SpiritsUnchained;
-import me.justahuman.spiritsunchained.implementation.mobs.AbstractCustomMob;
 import me.justahuman.spiritsunchained.listeners.PlayerArmorListener;
 import me.justahuman.spiritsunchained.managers.ConfigManager;
 import me.justahuman.spiritsunchained.managers.SpiritEntityManager;

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
@@ -318,11 +318,11 @@ public class SpiritUtils {
         item.setItemMeta(meta);
     }
     @ParametersAreNonnullByDefault
-    public static Collection<Entity> getNearbySpirits(Location location) {
-        final Collection<Entity> returnList = new ArrayList<>();
-        for (LivingEntity entity : spiritEntityManager.entityCollection) {
-            if (entity.getLocation().isWorldLoaded() && location.isWorldLoaded() && entity.getLocation().getWorld() == location.getWorld() && location.distanceSquared(entity.getLocation()) <= Math.pow(64, 2)) {
-                returnList.add(entity);
+    public static Collection<LivingEntity> getNearbySpirits(Location location, int distance) {
+        final Collection<LivingEntity> returnList = new ArrayList<>();
+        for (LivingEntity livingEntity : spiritEntityManager.getCustomLivingEntities()) {
+            if (livingEntity.getLocation().isWorldLoaded() && location.isWorldLoaded() && livingEntity.getLocation().getWorld() == location.getWorld() && location.distanceSquared(livingEntity.getLocation()) <= Math.pow(distance, 2)) {
+                returnList.add(livingEntity);
             }
         }
         return returnList;

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
@@ -388,10 +388,10 @@ public class SpiritUtils {
         return PersistentDataAPI.hasBoolean(itemStack.getItemMeta(), Keys.spiritLocked) && PersistentDataAPI.getBoolean(itemStack.getItemMeta(), Keys.spiritLocked);
     }
 
-    public static Collection<Player> getNearImbued(Location location) {
-        final Collection<UUID> collection = PlayerArmorListener.getCanSeeUUIDList();
-        final Collection<Player> toReturn = new ArrayList<>();
-        for (UUID uuid : collection) {
+    public static Set<Player> getNearImbued(Location location) {
+        final Set<UUID> set = PlayerArmorListener.getCanSeeUUIDList();
+        final Set<Player> toReturn = new HashSet<>();
+        for (UUID uuid : set) {
             final Player player = Bukkit.getPlayer(uuid);
             if (player != null && player.getWorld() == location.getWorld() && location.distanceSquared(player.getLocation()) <= Math.pow(64, 2)) {
                 toReturn.add(player);

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -71,6 +70,7 @@ public class SpiritUtils {
     private static final Map<EntityType, SpiritDefinition> spiritMap = spiritsManager.getSpiritMap();
     private static final SpiritsUnchained instance = SpiritsUnchained.getInstance();
     private static final FileConfiguration config = instance.getConfig();
+    private static final ThreadLocalRandom random = ThreadLocalRandom.current();
 
     public static String getTranslation(String path) {
         return configManager.getTranslation(path);
@@ -333,7 +333,7 @@ public class SpiritUtils {
         final Biome biome = location.getBlock().getBiome();
         final World.Environment dimension = world.getEnvironment();
         final boolean isDay = world.isDayTime();
-        final int chance = ThreadLocalRandom.current().nextInt(1, 101);
+        final int chance = random(1, 101);
         String spirit = null;
         final int tier;
         if (chance == 100) { // 1% Chance
@@ -457,8 +457,8 @@ public class SpiritUtils {
 
     public static Block getSpawnBlock(Location location) {
         final World world = location.getWorld();
-        final int x = new Random().nextInt(17) * (new Random().nextBoolean() ? 1 : -1) + location.getBlockX();
-        final int z = new Random().nextInt(17) * (new Random().nextBoolean() ? 1 : -1) + location.getBlockZ();
+        final int x = random(0,17) * (random() ? 1 : -1) + location.getBlockX();
+        final int z = random(0, 17) * (random() ? 1 : -1) + location.getBlockZ();
         int y = location.getBlockY();
         if (world.getBlockAt(x,y,z).getType() != Material.AIR) {
             boolean foundAir = false;
@@ -551,11 +551,19 @@ public class SpiritUtils {
         }
     }
     
-    public static long random(final long origin, final long bound) {
-        return ThreadLocalRandom.current().nextLong(origin, bound);
+    public static int random(int origin, int bound) {
+        return random.nextInt(origin, bound);
+    }
+    
+    public static double random(double origin, double bound) {
+         return random.nextDouble(origin, bound);
+    }
+    
+    public static boolean random() {
+        return random.nextBoolean();
     }
 
-    public static boolean chance(final int chance) {
+    public static boolean chance(int chance) {
         return random(1, 101) <= chance;
     }
 }

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
@@ -377,7 +377,7 @@ public class SpiritUtils {
     }
 
     public static boolean canSpawn() {
-        return spiritEntityManager.entityCollection.size() < config.getInt("options.max-spirits", 40);
+        return spiritEntityManager.entitySet.size() < config.getInt("options.max-spirits", 40);
     }
 
     public static boolean imbuedCheck(ItemStack helmetItem) {

--- a/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
+++ b/src/main/java/me/justahuman/spiritsunchained/utils/SpiritUtils.java
@@ -63,8 +63,7 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class SpiritUtils {
-
-    public static final Map<Integer, Entity> spiritIdMap = new HashMap<>();
+    
     private static final ConfigManager configManager = SpiritsUnchained.getConfigManager();
     private static final SpiritEntityManager spiritEntityManager = SpiritsUnchained.getSpiritEntityManager();
     private static final SpiritsManager spiritsManager = SpiritsUnchained.getSpiritsManager();
@@ -265,12 +264,12 @@ public class SpiritUtils {
         return false;
     }
 
-    private static boolean tryUseSpirit(Player player, ItemStack spiritItem, SpiritDefinition definition, boolean notif) {
+    private static boolean tryUseSpirit(Player player, ItemStack spiritItem, SpiritDefinition definition, boolean notify) {
         final String name = ChatColors.color(tierColor(definition.getTier()) + ChatUtils.humanize(definition.getType().name()));
         final ItemMeta meta = spiritItem.getItemMeta();
         final String state = PersistentDataAPI.getString(meta, Keys.spiritStateKey);
         final Map<String, Object> traitInfo = getTraitInfo(definition.getTrait());
-        if (getStates().indexOf(state) <= 2 && notif) {
+        if (getStates().indexOf(state) <= 2 && notify) {
             player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(getTranslation("messages.traits.incorrect_state").replace("{tier_color_and_mob_type}", name)));
             return false;
         }
@@ -283,7 +282,7 @@ public class SpiritUtils {
                 player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(getTranslation("messages.traits.used_passive").replace("{tier_color_and_mob_type}", name)));
             }
             return true;
-        } else if (notif) {
+        } else if (notify) {
             player.sendMessage(ChatMessageType.ACTION_BAR, new TextComponent(getTranslation("messages.traits.not_enough_progress").replace("{tier_color_and_mob_type}", name).replace("{progress}", String.valueOf(progress)).replace("{required_progress}", String.valueOf(usage))));
         }
         return false;
@@ -378,7 +377,7 @@ public class SpiritUtils {
     }
 
     public static boolean canSpawn() {
-        return spiritIdMap.size() < config.getInt("options.max-spirits", 40);
+        return spiritEntityManager.entityCollection.size() < config.getInt("options.max-spirits", 40);
     }
 
     public static boolean imbuedCheck(ItemStack helmetItem) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -37,3 +37,6 @@ options:
 
   # Should Mobs Spawned from Mob Spawners be able to release Spirits
   spawner-spirits: true
+
+  # Should spirits only spawn for Survival Players
+  require-survival: true

--- a/src/main/resources/language.yml
+++ b/src/main/resources/language.yml
@@ -141,18 +141,21 @@ names:
       lore:
         - ""
         - "&7Automatically catch Spirits"
+        - "&7By catching the Spirits in a Radius of 10 blocks around the Machine."
         - ""
     electric_spirit_bottler:
       name: "&aElectric Spirit Bottler"
       lore:
         - ""
         - "&7Automatically bottle Spirits"
+        - "&7By bottling the Spirits in a Radius of 10 blocks around the Machine."
         - ""
     electric_spirit_writer:
       name: "&aElectric Spirit Writer"
       lore:
         - ""
         - "&7Automatically let Spirits Write to A Spirit Book"
+        - "&7By inputting a Captured Spirit and a Spirit Book to the Machine"
         - ""
     altars:
       lore:


### PR DESCRIPTION
Overall this update is mainly QOL and performance! If any server owners had to lower the tick rate due to spirits being a more intensive addon this should help significantly and you can increase it again.

Changes:

- Universal Spawn Chance decreased to 10% (from 20%, the reasoning being with the spawn fixes 10% is plenty fast.)
- Spirit Bottle to Ectoplasm Recipe is now in the top left corner instead of center (for QOL)
- Lore of Electric Machines now includes the Radius it works in (Delete those entries in language.yml to update)

Additions:

- Config option to require survival for spirit spawning
- Natural Passing on of Spirits (Higher tier spirit, longer it takes) #23 

Fixes:

- Fixed Spirit Spawning Cap being filled but never Un-filling (you guys were right, I was wrong)

Optimizations: (Only important for Server Owners)

- Spirit Ticking majorly optimized, the entities unique id's are cached instead of checking through EVERY entity to see if its a spirit
- Who can see spirits is now Cached instead of checking each time we want to send particles
- Hiding the allays of spirits is only called with it spawns and when a player joins instead of every tick (what was I thinking)
- Replaced all calls of location.distance() with location.distanceSquared() which removes the heavy sqrt call.